### PR TITLE
Implements `kcm install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Usage:
   kcm init [--conf-dir=<dir>] [--num-dp-cores=<num>] [--num-cp-cores=<num>]
   kcm (describe | reconcile) [--conf-dir=<dir>]
   kcm isolate [--conf-dir=<dir>] --pool=<pool> <command> [-- <args> ...]
+  kcm install --install-dir=<dir>
 
 Options:
   -h --help             Show this screen.
   --version             Show version.
   --conf-dir=<dir>      KCM configuration directory [default: /etc/kcm].
+  --install-dir=<dir>   KCM install directory.
   --num-dp-cores=<num>  Number of data plane cores [default: 4].
   --num-cp-cores=<num>  Number of control plane cores [default: 1].
   --pool=<pool>         Pool name: either infra, controlplane or dataplane.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 tox>=2.5, <3.0
 docopt>=0.6, <1.0
 psutil>=5.0, <5.5
+pyinstaller>=3.2, <4.0

--- a/tests/integration/test_kcm_install.py
+++ b/tests/integration/test_kcm_install.py
@@ -1,0 +1,18 @@
+from . import integration
+import os
+import tempfile
+
+
+def test_kcm_install():
+    # Install kcm to a temporary directory.
+    install_dir = tempfile.mkdtemp()
+    integration.execute(integration.kcm(),
+                        ["install",
+                         "--install-dir={}".format(install_dir)])
+    installed_kcm = os.path.join(install_dir, "kcm")
+
+    # Check installed kcm executable output against the original script.
+    assert (integration.execute(installed_kcm, ["--help"]) ==
+            integration.execute(integration.kcm(), ["--help"]))
+    assert (integration.execute(installed_kcm, ["--version"]) ==
+            integration.execute(integration.kcm(), ["--version"]))


### PR DESCRIPTION
Implements `kcm install`.

To use:

`docker run -it kcm install --install-dir=/target`
_(optional: mount host volume to `/target` to export from the container)_