### PR TITLE
Refactored top-level kcm program into modules.

### DIFF
--- a/intel/describe.py
+++ b/intel/describe.py
@@ -1,0 +1,8 @@
+from . import config
+import json
+
+
+def describe(conf_dir):
+    c = config.Config(conf_dir)
+    with c.lock():
+        print(json.dumps(c.as_dict(), sort_keys=True, indent=2))

--- a/intel/init.py
+++ b/intel/init.py
@@ -1,0 +1,88 @@
+from . import config
+import collections
+import logging
+import subprocess
+
+
+def init(conf_dir, num_dp_cores, num_cp_cores):
+    check_hugepages()
+    cpumap = discover_topo()
+    logging.info("Writing config to {}.".format(conf_dir))
+    logging.info("Requested data plane cores = {}.".format(num_dp_cores))
+    logging.info("Requested control plane cores = {}.".format(num_cp_cores))
+    c = config.new(conf_dir)
+    with c.lock():
+        logging.info("Adding dataplane pool.")
+        dp = c.add_pool("dataplane", True)
+        for i in range(int(num_dp_cores)):
+            if not cpumap:
+                raise KeyError("No more cpus left to assign for data plane")
+            k, v = cpumap.popitem()
+            logging.info("Adding {} cpus to the dataplane pool.".format(v))
+            dp.add_cpu_list(v)
+        logging.info("Adding controlplane pool.")
+        cp = c.add_pool("controlplane", False)
+        cpus = ""
+        for i in range(int(num_cp_cores)):
+            if not cpumap:
+                raise KeyError("No more cpus left to assign for control plane")
+            k, v = cpumap.popitem()
+            if cpus:
+                cpus = cpus + "," + v
+            else:
+                cpus = v
+        logging.info("Adding {} cpus to the controlplane pool.".format(cpus))
+        cp.add_cpu_list(cpus)
+        logging.info("Adding infra pool.")
+        infra = c.add_pool("infra", False)
+        cpus = ""
+        if not cpumap:
+            raise KeyError("No more cpus left to assign for infra")
+        for k, v in cpumap.items():
+            if cpus:
+                cpus = cpus + "," + v
+            else:
+                cpus = v
+        logging.info("Adding {} cpus to the infra pool.".format(cpus))
+        infra.add_cpu_list(cpus)
+
+
+def check_hugepages():
+    fd = open("/proc/meminfo", "r")
+    content = fd.read()
+    lines = content.split("\n")
+    for line in lines:
+        if line.startswith("HugePages_Free"):
+            parts = line.split()
+            num_free = int(parts[1])
+            if num_free == 0:
+                logging.warning("No hugepages are free")
+                return
+
+
+# Discover cpu topology (physical to logical core mapping).
+def discover_topo():
+    cmd_out = subprocess.check_output("lscpu -p", shell=True)
+    return parse_topo(cmd_out.decode("UTF-8"))
+
+
+# Returns a map between physical and logical cpu cores using
+# `lscpu -p` output.
+# `lscpu -p` output has the following format:
+# # The following is the parsable format, which can be fed to other
+# # programs. Each different item in every column has an unique ID
+# # starting from zero.
+# # CPU,Core,Socket,Node,,L1d,L1i,L2,L3
+# 0,0,0,0,,0,0,0,0
+# 1,1,0,0,,1,1,1,0
+def parse_topo(topo_output):
+    lines = topo_output.split("\n")
+    cpumap = collections.OrderedDict()
+    for line in lines:
+        if not line.startswith("#") and len(line) > 0:
+            cpuinfo = line.split(",")
+            if cpuinfo[1] in cpumap:
+                cpumap[cpuinfo[1]] = cpumap[cpuinfo[1]] + "," + cpuinfo[0]
+            else:
+                cpumap[cpuinfo[1]] = cpuinfo[0]
+    return cpumap

--- a/intel/install.py
+++ b/intel/install.py
@@ -1,0 +1,17 @@
+from . import util
+import logging
+import os
+import subprocess
+
+
+def install(install_dir):
+    kcm_path = os.path.join(util.kcm_root(), "kcm.py")
+    # Using pyinstaller: http://www.pyinstaller.org
+    # to produce an x86-64 ELF executable named `kcm` in the
+    # supplied installation directory.
+    subprocess.check_call(
+        "pyinstaller --onefile --distpath={} {}".format(
+            install_dir,
+            kcm_path),
+        shell=True)
+    logging.info("Installed kcm to {}".format(install_dir))

--- a/intel/isolate.py
+++ b/intel/isolate.py
@@ -1,0 +1,40 @@
+from . import config
+import os
+import random
+import subprocess
+
+
+def isolate(conf_dir, pool_name, command, args):
+    # TODO: handle signals properly, e.g. to release exclusive cpu lists.
+    # It's common for container managers to send SIG_TERM shortly before
+    # sending SIG_KILL.
+    c = config.Config(conf_dir)
+    with c.lock():
+        pools = c.pools()
+        if pool_name not in pools:
+            raise KeyError("Requested pool {} does not exist"
+                           .format(pool_name))
+        pool = pools[pool_name]
+        if pool.exclusive():
+            for cl in pool.cpu_lists().values():
+                if len(cl.tasks()) == 0:
+                    clist = cl
+                    break
+        else:
+            # NOTE(CD): This allocation algorithm is probably an
+            # oversimplification, however for known use cases the non-exclusive
+            # pools should never have more than one cpu list anyhow.
+            # If that ceases to hold in the future, we could explore population
+            # or load-based spreading. Keeping it simple for now.
+            clist = random.choice(list(pool.cpu_lists().values()))
+        if not clist:
+            raise SystemError("No free cpu lists in pool {}".format(pool_name))
+        clist.add_task(os.getpid())
+    # NOTE: we spawn the child process after exiting the config lock context.
+    try:
+        subprocess.check_call("numactl --physcpubind={} -- {} {}".format(
+            clist.cpus(), command, " ".join(args)),
+            shell=True)
+    finally:
+        with c.lock():
+            clist.remove_task(os.getpid())

--- a/intel/reconcile.py
+++ b/intel/reconcile.py
@@ -1,0 +1,13 @@
+from . import config
+import psutil
+
+
+def reconcile(conf_dir):
+    # TODO: Run reconcile periodically in the background.
+    c = config.Config(conf_dir)
+    with c.lock():
+        for pool_name, pool in c.pools().items():
+            for cl in pool.cpu_lists().values():
+                for task in cl.tasks():
+                    if not psutil.pid_exists(task):
+                        cl.remove_task(task)

--- a/intel/util.py
+++ b/intel/util.py
@@ -1,49 +1,5 @@
-import logging
-import subprocess
-import collections
 from os.path import normpath, realpath, join, pardir
 
 
 def kcm_root():
     return normpath(realpath(join(__file__, pardir, pardir)))
-
-
-def check_hugepages():
-    fd = open("/proc/meminfo", "r")
-    content = fd.read()
-    lines = content.split("\n")
-    for line in lines:
-        if line.startswith("HugePages_Free"):
-            parts = line.split()
-            num_free = int(parts[1])
-            if num_free == 0:
-                logging.warning("No hugepages are free")
-                return
-
-
-# Discover cpu topology (physical to logical core mapping).
-def discover_topo():
-    cmd_out = subprocess.check_output("lscpu -p", shell=True)
-    return parse_topo(cmd_out.decode("UTF-8"))
-
-
-# Returns a map between physical and logical cpu cores using
-# `lscpu -p` output.
-# `lscpu -p` output has the following format:
-# # The following is the parsable format, which can be fed to other
-# # programs. Each different item in every column has an unique ID
-# # starting from zero.
-# # CPU,Core,Socket,Node,,L1d,L1i,L2,L3
-# 0,0,0,0,,0,0,0,0
-# 1,1,0,0,,1,1,1,0
-def parse_topo(topo_output):
-    lines = topo_output.split("\n")
-    cpumap = collections.OrderedDict()
-    for line in lines:
-        if not line.startswith("#") and len(line) > 0:
-            cpuinfo = line.split(",")
-            if cpuinfo[1] in cpumap:
-                cpumap[cpuinfo[1]] = cpumap[cpuinfo[1]] + "," + cpuinfo[0]
-            else:
-                cpumap[cpuinfo[1]] = cpuinfo[0]
-    return cpumap

--- a/kcm.py
+++ b/kcm.py
@@ -20,146 +20,32 @@ Options:
   --num-cp-cores=<num>  Number of control plane cores [default: 1].
   --pool=<pool>         Pool name: either infra, controlplane or dataplane.
 """
-from intel import config, util
+from intel import describe, init, install, isolate, reconcile
 from docopt import docopt
-import json
-import os
-import random
-import subprocess
 import logging
-import psutil
 
 
 def main():
     logging.basicConfig(level=logging.INFO)
     args = docopt(__doc__, version="KCM 0.1.0")
     if args["init"]:
-        init(args["--conf-dir"],
-             args["--num-dp-cores"],
-             args["--num-cp-cores"])
+        init.init(args["--conf-dir"],
+                  args["--num-dp-cores"],
+                  args["--num-cp-cores"])
         return
     if args["describe"]:
-        describe(args["--conf-dir"])
+        describe.describe(args["--conf-dir"])
         return
     if args["isolate"]:
-        isolate(args["--conf-dir"], args["--pool"],
-                args["<command>"], args["<args>"])
+        isolate.isolate(args["--conf-dir"], args["--pool"],
+                        args["<command>"], args["<args>"])
         return
     if args["reconcile"]:
-        reconcile(args["--conf-dir"])
+        reconcile.reconcile(args["--conf-dir"])
         return
     if args["install"]:
-        install(args["--install-dir"])
+        install.install(args["--install-dir"])
         return
-
-
-def init(conf_dir, num_dp_cores, num_cp_cores):
-    util.check_hugepages()
-    cpumap = util.discover_topo()
-    logging.info("Writing config to {}.".format(conf_dir))
-    logging.info("Requested data plane cores = {}.".format(num_dp_cores))
-    logging.info("Requested control plane cores = {}.".format(num_cp_cores))
-    c = config.new(conf_dir)
-    with c.lock():
-        logging.info("Adding dataplane pool.")
-        dp = c.add_pool("dataplane", True)
-        for i in range(int(num_dp_cores)):
-            if not cpumap:
-                raise KeyError("No more cpus left to assign for data plane")
-            k, v = cpumap.popitem()
-            logging.info("Adding {} cpus to the dataplane pool.".format(v))
-            dp.add_cpu_list(v)
-        logging.info("Adding controlplane pool.")
-        cp = c.add_pool("controlplane", False)
-        cpus = ""
-        for i in range(int(num_cp_cores)):
-            if not cpumap:
-                raise KeyError("No more cpus left to assign for control plane")
-            k, v = cpumap.popitem()
-            if cpus:
-                cpus = cpus + "," + v
-            else:
-                cpus = v
-        logging.info("Adding {} cpus to the controlplane pool.".format(cpus))
-        cp.add_cpu_list(cpus)
-        logging.info("Adding infra pool.")
-        infra = c.add_pool("infra", False)
-        cpus = ""
-        if not cpumap:
-            raise KeyError("No more cpus left to assign for infra")
-        for k, v in cpumap.items():
-            if cpus:
-                cpus = cpus + "," + v
-            else:
-                cpus = v
-        logging.info("Adding {} cpus to the infra pool.".format(cpus))
-        infra.add_cpu_list(cpus)
-
-
-def describe(conf_dir):
-    c = config.Config(conf_dir)
-    with c.lock():
-        print(json.dumps(c.as_dict(), sort_keys=True, indent=2))
-
-
-def isolate(conf_dir, pool_name, command, args):
-    # TODO: handle signals properly, e.g. to release exclusive cpu lists.
-    # It's common for container managers to send SIG_TERM shortly before
-    # sending SIG_KILL.
-    c = config.Config(conf_dir)
-    with c.lock():
-        pools = c.pools()
-        if pool_name not in pools:
-            raise KeyError("Requested pool {} does not exist"
-                           .format(pool_name))
-        pool = pools[pool_name]
-        if pool.exclusive():
-            for cl in pool.cpu_lists().values():
-                if len(cl.tasks()) == 0:
-                    clist = cl
-                    break
-        else:
-            # NOTE(CD): This allocation algorithm is probably an
-            # oversimplification, however for known use cases the non-exclusive
-            # pools should never have more than one cpu list anyhow.
-            # If that ceases to hold in the future, we could explore population
-            # or load-based spreading. Keeping it simple for now.
-            clist = random.choice(list(pool.cpu_lists().values()))
-        if not clist:
-            raise SystemError("No free cpu lists in pool {}".format(pool_name))
-        clist.add_task(os.getpid())
-    # NOTE: we spawn the child process after exiting the config lock context.
-    try:
-        subprocess.check_call("numactl --physcpubind={} -- {} {}".format(
-            clist.cpus(), command, " ".join(args)),
-            shell=True)
-    finally:
-        with c.lock():
-            clist.remove_task(os.getpid())
-
-
-def reconcile(conf_dir):
-    # TODO: Run reconcile periodically in the background.
-    c = config.Config(conf_dir)
-    with c.lock():
-        for pool_name, pool in c.pools().items():
-            for cl in pool.cpu_lists().values():
-                for task in cl.tasks():
-                    if not psutil.pid_exists(task):
-                        cl.remove_task(task)
-
-
-def install(install_dir):
-    kcm_path = os.path.realpath(__file__)
-    # Using pyinstaller: http://www.pyinstaller.org
-    # to produce an x86-64 ELF executable named `kcm` in the
-    # supplied installation directory.
-    subprocess.check_call(
-        "pyinstaller --onefile --distpath={} {}".format(
-            install_dir,
-            kcm_path),
-        shell=True)
-    logging.info("Installed kcm to {}".format(install_dir))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,10 +1,52 @@
-import os
+from intel import config, init
 import collections
-import tempfile
+import os
 import pytest
-import kcm
-from intel import config
+import tempfile
 from unittest.mock import patch, MagicMock
+
+
+def test_init_discover_topo():
+    cpumap = init.discover_topo()
+    assert len(cpumap) > 0
+
+
+def test_init_parse_topo():
+    input1 = """#The following is the parsable format, which can be fed to other
+# programs. Each different item in every column has an unique ID
+# starting from zero.
+# CPU,Core,Socket,Node,,L1d,L1i,L2,L3
+0,0,0,0,,0,0,0,0
+1,1,0,0,,1,1,1,0
+"""
+    input2 = """#The following is the parsable format, which can be fed to other
+# programs. Each different item in every column has an unique ID
+# starting from zero.
+# CPU,Core,Socket,Node,,L1d,L1i,L2,L3
+0,0,0,0,,0,0,0,0
+1,1,0,0,,1,1,1,0
+2,2,0,0,,2,2,2,0
+3,3,0,0,,3,3,3,0
+4,0,0,0,,0,0,0,0
+5,1,0,0,,1,1,1,0
+6,2,0,0,,2,2,2,0
+7,3,0,0,,3,3,3,0
+"""
+    cpumap = init.parse_topo(input1)
+    assert len(cpumap) == 2
+    assert "0" in cpumap
+    assert "1" in cpumap
+
+    cpumap = init.parse_topo(input2)
+    assert len(cpumap) == 4
+    assert "0" in cpumap
+    assert "1" in cpumap
+    assert "2" in cpumap
+    assert "3" in cpumap
+    assert cpumap["0"] == "0,4"
+    assert cpumap["1"] == "1,5"
+    assert cpumap["2"] == "2,6"
+    assert cpumap["3"] == "3,7"
 
 
 def test_init_success1():
@@ -13,10 +55,10 @@ def test_init_success1():
     discover_topo_out["1"] = "1,5"
     discover_topo_out["2"] = "2,6"
     discover_topo_out["3"] = "3,7"
-    with patch('intel.util.discover_topo',
+    with patch('intel.init.discover_topo',
                MagicMock(return_value=discover_topo_out)):
         temp_dir = tempfile.mkdtemp()
-        kcm.init(os.path.join(temp_dir, "init"), 2, 1)
+        init.init(os.path.join(temp_dir, "init"), 2, 1)
         c = config.Config(os.path.join(temp_dir, "init"))
         pools = c.pools()
         assert len(pools) == 3
@@ -41,10 +83,10 @@ def test_init_success2():
     discover_topo_out["1"] = "1,5"
     discover_topo_out["2"] = "2,6"
     discover_topo_out["3"] = "3,7"
-    with patch('intel.util.discover_topo',
+    with patch('intel.init.discover_topo',
                MagicMock(return_value=discover_topo_out)):
         temp_dir = tempfile.mkdtemp()
-        kcm.init(os.path.join(temp_dir, "init"), 1, 2)
+        init.init(os.path.join(temp_dir, "init"), 1, 2)
         c = config.Config(os.path.join(temp_dir, "init"))
         pools = c.pools()
         assert len(pools) == 3
@@ -68,10 +110,10 @@ def test_init_success3():
     discover_topo_out["1"] = "1,5"
     discover_topo_out["2"] = "2,6"
     discover_topo_out["3"] = "3,7"
-    with patch('intel.util.discover_topo',
+    with patch('intel.init.discover_topo',
                MagicMock(return_value=discover_topo_out)):
         temp_dir = tempfile.mkdtemp()
-        kcm.init(os.path.join(temp_dir, "init"), 1, 1)
+        init.init(os.path.join(temp_dir, "init"), 1, 1)
         c = config.Config(os.path.join(temp_dir, "init"))
         pools = c.pools()
         assert len(pools) == 3
@@ -92,11 +134,11 @@ def test_init_success3():
 def test_init_failure1():
     discover_topo_out = collections.OrderedDict()
     discover_topo_out["0"] = "0,4"
-    with patch('intel.util.discover_topo',
+    with patch('intel.init.discover_topo',
                MagicMock(return_value=discover_topo_out)):
         temp_dir = tempfile.mkdtemp()
         with pytest.raises(KeyError) as err:
-            kcm.init(os.path.join(temp_dir, "init"), 2, 1)
+            init.init(os.path.join(temp_dir, "init"), 2, 1)
         expected_msg = "No more cpus left to assign for data plane"
         assert err.value.args[0] == expected_msg
 
@@ -105,11 +147,11 @@ def test_init_failure2():
     discover_topo_out = collections.OrderedDict()
     discover_topo_out["0"] = "0,4"
     discover_topo_out["1"] = "1,5"
-    with patch('intel.util.discover_topo',
+    with patch('intel.init.discover_topo',
                MagicMock(return_value=discover_topo_out)):
         temp_dir = tempfile.mkdtemp()
         with pytest.raises(KeyError) as err:
-            kcm.init(os.path.join(temp_dir, "init"), 2, 1)
+            init.init(os.path.join(temp_dir, "init"), 2, 1)
         expected_msg = "No more cpus left to assign for control plane"
         assert err.value.args[0] == expected_msg
 
@@ -119,10 +161,10 @@ def test_init_failure3():
     discover_topo_out["0"] = "0,4"
     discover_topo_out["1"] = "1,5"
     discover_topo_out["2"] = "2,6"
-    with patch('intel.util.discover_topo',
+    with patch('intel.init.discover_topo',
                MagicMock(return_value=discover_topo_out)):
         temp_dir = tempfile.mkdtemp()
         with pytest.raises(KeyError) as err:
-            kcm.init(os.path.join(temp_dir, "init"), 2, 1)
+            init.init(os.path.join(temp_dir, "init"), 2, 1)
         expected_msg = "No more cpus left to assign for infra"
         assert err.value.args[0] == expected_msg

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,51 +1,7 @@
 import os
-
 from intel import util
 
 
 def test_kcm_root():
     result = util.kcm_root()
     assert os.path.isdir(os.path.join(result, "tests", "data"))
-
-
-def test_discover_topo():
-    cpumap = util.discover_topo()
-    assert len(cpumap) > 0
-
-
-def test_parse_topo():
-    input1 = """#The following is the parsable format, which can be fed to other
-# programs. Each different item in every column has an unique ID
-# starting from zero.
-# CPU,Core,Socket,Node,,L1d,L1i,L2,L3
-0,0,0,0,,0,0,0,0
-1,1,0,0,,1,1,1,0
-"""
-    input2 = """#The following is the parsable format, which can be fed to other
-# programs. Each different item in every column has an unique ID
-# starting from zero.
-# CPU,Core,Socket,Node,,L1d,L1i,L2,L3
-0,0,0,0,,0,0,0,0
-1,1,0,0,,1,1,1,0
-2,2,0,0,,2,2,2,0
-3,3,0,0,,3,3,3,0
-4,0,0,0,,0,0,0,0
-5,1,0,0,,1,1,1,0
-6,2,0,0,,2,2,2,0
-7,3,0,0,,3,3,3,0
-"""
-    cpumap = util.parse_topo(input1)
-    assert len(cpumap) == 2
-    assert "0" in cpumap
-    assert "1" in cpumap
-
-    cpumap = util.parse_topo(input2)
-    assert len(cpumap) == 4
-    assert "0" in cpumap
-    assert "1" in cpumap
-    assert "2" in cpumap
-    assert "3" in cpumap
-    assert cpumap["0"] == "0,4"
-    assert cpumap["1"] == "1,5"
-    assert cpumap["2"] == "2,6"
-    assert cpumap["3"] == "3,7"


### PR DESCRIPTION
Rationale:
- make the top-level kcm.py more readable
- encourage features to be factored into smaller functions for testability
- decrease volume of the `intel.util` module

_Note: will need rebase assuming #20 merges first._