### PR TITLE
Release config file lock and exit after timeout.

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,8 @@
+from intel import util
+import os
+
+
+# Returns the absolute path to the test config directory with the supplied
+# name.
+def conf_dir(name):
+    return os.path.join(util.kcm_root(), "tests", "data", "config", name)

--- a/tests/integration/integration.py
+++ b/tests/integration/integration.py
@@ -8,12 +8,6 @@ def kcm():
     return os.path.join(util.kcm_root(), "kcm.py")
 
 
-# Returns the absolute path to the test config directory with the supplied
-# name.
-def conf_dir(name):
-    return os.path.join(util.kcm_root(), "tests", "data", "config", name)
-
-
 # Returns resulting stdout buffer from interpreting the supplied command with
 # a shell. Raises process errors if the command exits nonzero.
 def execute(cmd, args):

--- a/tests/integration/test_kcm_describe.py
+++ b/tests/integration/test_kcm_describe.py
@@ -1,8 +1,9 @@
+from .. import helpers
 from . import integration
 
 
 def test_kcm_describe_ok():
-    args = ["describe", "--conf-dir={}".format(integration.conf_dir("ok"))]
+    args = ["describe", "--conf-dir={}".format(helpers.conf_dir("ok"))]
     assert integration.execute(integration.kcm(), args) == b"""{
   "path": "/kcm/tests/data/config/ok",
   "pools": {
@@ -72,7 +73,7 @@ def test_kcm_describe_ok():
 
 def test_kcm_describe_minimal():
     args = ["describe",
-            "--conf-dir={}".format(integration.conf_dir("minimal"))]
+            "--conf-dir={}".format(helpers.conf_dir("minimal"))]
     assert integration.execute(integration.kcm(), args) == b"""{
   "path": "/kcm/tests/data/config/minimal",
   "pools": {

--- a/tests/integration/test_kcm_isolate.py
+++ b/tests/integration/test_kcm_isolate.py
@@ -1,3 +1,4 @@
+from .. import helpers
 from . import integration
 from intel import config
 import os
@@ -8,7 +9,7 @@ import tempfile
 
 def test_kcm_isolate_shared():
     args = ["isolate",
-            "--conf-dir={}".format(integration.conf_dir("minimal")),
+            "--conf-dir={}".format(helpers.conf_dir("minimal")),
             "--pool=shared",
             "echo",
             "--",
@@ -18,7 +19,7 @@ def test_kcm_isolate_shared():
 
 def test_kcm_isolate_exclusive():
     args = ["isolate",
-            "--conf-dir={}".format(integration.conf_dir("minimal")),
+            "--conf-dir={}".format(helpers.conf_dir("minimal")),
             "--pool=exclusive",
             "echo",
             "--",
@@ -32,7 +33,7 @@ def test_kcm_isolate_pid_bookkeeping():
     integration.execute(
         "cp",
         ["-r",
-         integration.conf_dir("minimal"),
+         helpers.conf_dir("minimal"),
          "{}".format(conf_dir)]
     )
     c = config.Config(conf_dir)

--- a/tests/integration/test_kcm_reconcile.py
+++ b/tests/integration/test_kcm_reconcile.py
@@ -1,3 +1,4 @@
+from .. import helpers
 from . import integration
 from intel import config
 import os
@@ -9,7 +10,7 @@ def test_kcm_reconcile():
     integration.execute(
         "cp",
         ["-r",
-         integration.conf_dir("ok"),
+         helpers.conf_dir("ok"),
          "{}".format(os.path.join(temp_dir, "reconcile"))]
     )
 


### PR DESCRIPTION
Also moves `integration.conf_dir(name)` to the `helpers` module so it can also be used in unit tests.