### PR TITLE
Remove the installed kcm binary after int tests.

### DIFF
--- a/tests/integration/test_kcm_install.py
+++ b/tests/integration/test_kcm_install.py
@@ -16,3 +16,5 @@ def test_kcm_install():
             integration.execute(integration.kcm(), ["--help"]))
     assert (integration.execute(installed_kcm, ["--version"]) ==
             integration.execute(integration.kcm(), ["--version"]))
+
+    integration.execute("rm", [installed_kcm])


### PR DESCRIPTION
Saves 9MB (6.25 floppy disks)