### PR TITLE
Split describe and reconcile in usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Usage:
   kcm (-h | --help)
   kcm --version
   kcm init [--conf-dir=<dir>] [--num-dp-cores=<num>] [--num-cp-cores=<num>]
-  kcm (describe | reconcile) [--conf-dir=<dir>]
+  kcm describe [--conf-dir=<dir>]
+  kcm reconcile [--conf-dir=<dir>]
   kcm isolate [--conf-dir=<dir>] --pool=<pool> <command> [-- <args> ...]
   kcm install --install-dir=<dir>
 

--- a/kcm.py
+++ b/kcm.py
@@ -7,7 +7,8 @@ Usage:
   kcm (-h | --help)
   kcm --version
   kcm init [--conf-dir=<dir>] [--num-dp-cores=<num>] [--num-cp-cores=<num>]
-  kcm (describe | reconcile) [--conf-dir=<dir>]
+  kcm describe [--conf-dir=<dir>]
+  kcm reconcile [--conf-dir=<dir>]
   kcm isolate [--conf-dir=<dir>] --pool=<pool> <command> [-- <args> ...]
   kcm install --install-dir=<dir>
 

--- a/tests/integration/test_kcm_help.py
+++ b/tests/integration/test_kcm_help.py
@@ -1,0 +1,24 @@
+from . import integration
+
+
+def test_kcm_help():
+    assert integration.execute(integration.kcm(), ["--help"]) == b"""kcm.
+
+Usage:
+  kcm (-h | --help)
+  kcm --version
+  kcm init [--conf-dir=<dir>] [--num-dp-cores=<num>] [--num-cp-cores=<num>]
+  kcm describe [--conf-dir=<dir>]
+  kcm reconcile [--conf-dir=<dir>]
+  kcm isolate [--conf-dir=<dir>] --pool=<pool> <command> [-- <args> ...]
+  kcm install --install-dir=<dir>
+
+Options:
+  -h --help             Show this screen.
+  --version             Show version.
+  --conf-dir=<dir>      KCM configuration directory [default: /etc/kcm].
+  --install-dir=<dir>   KCM install directory.
+  --num-dp-cores=<num>  Number of data plane cores [default: 4].
+  --num-cp-cores=<num>  Number of control plane cores [default: 1].
+  --pool=<pool>         Pool name: either infra, controlplane or dataplane.
+"""


### PR DESCRIPTION
Making help doc easier for humans to parse.

- Also added an integration test for `kcm --help`.