### PR TITLE
Propagate sig-term to child process in isolate.

### DIFF
--- a/tests/integration/test_kcm_isolate.py
+++ b/tests/integration/test_kcm_isolate.py
@@ -40,9 +40,8 @@ def test_kcm_isolate_pid_bookkeeping():
         "cp",
         ["-r",
          helpers.conf_dir("minimal"),
-         "{}".format(conf_dir)],
-        proc_env
-    )
+         "{}".format(conf_dir)])
+
     c = config.Config(conf_dir)
 
     fifo = helpers.rand_str()
@@ -53,8 +52,7 @@ def test_kcm_isolate_pid_bookkeeping():
             "isolate",
             "--conf-dir={}".format(conf_dir),
             "--pool=shared",
-            "echo 1 > {} && cat {}".format(fifo, fifo)
-        ])
+            "echo 1 > {} && cat {}".format(fifo, fifo)])
     kcm = psutil.Process(p.pid)
     # Wait for subprocess to exist
     helpers.execute("cat {}".format(fifo))
@@ -62,6 +60,74 @@ def test_kcm_isolate_pid_bookkeeping():
     assert kcm.pid in clist.tasks()
     # Signal subprocess to exit
     helpers.execute("echo 1 > {}".format(fifo))
+    # Wait for kcm process to terminate
+    kcm.wait()
+    assert kcm.pid not in clist.tasks()
+    helpers.execute("rm {}".format(fifo))
+
+
+def test_kcm_isolate_sigkill():
+    temp_dir = tempfile.mkdtemp()
+    conf_dir = os.path.join(temp_dir, "isolate")
+    helpers.execute(
+        "cp",
+        ["-r",
+         helpers.conf_dir("minimal"),
+         "{}".format(conf_dir)])
+
+    c = config.Config(conf_dir)
+
+    fifo = helpers.rand_str()
+    helpers.execute("mkfifo", [fifo])
+
+    p = subprocess.Popen([
+            integration.kcm(),
+            "isolate",
+            "--conf-dir={}".format(conf_dir),
+            "--pool=shared",
+            "echo 1 > {} && sleep 300".format(fifo)])
+    kcm = psutil.Process(p.pid)
+    # Wait for subprocess to exist
+    helpers.execute("cat {}".format(fifo))
+    clist = c.pool("shared").cpu_list("0")
+    assert kcm.pid in clist.tasks()
+
+    # Send sigkill to kcm
+    kcm.kill()
+    # Wait for kcm process to exit
+    kcm.wait()
+    assert kcm.pid in clist.tasks()
+    helpers.execute("rm {}".format(fifo))
+
+
+def test_kcm_isolate_sigterm():
+    temp_dir = tempfile.mkdtemp()
+    conf_dir = os.path.join(temp_dir, "isolate")
+    helpers.execute(
+        "cp",
+        ["-r",
+         helpers.conf_dir("minimal"),
+         "{}".format(conf_dir)])
+
+    c = config.Config(conf_dir)
+
+    fifo = helpers.rand_str()
+    helpers.execute("mkfifo", [fifo])
+
+    p = subprocess.Popen([
+            integration.kcm(),
+            "isolate",
+            "--conf-dir={}".format(conf_dir),
+            "--pool=shared",
+            "echo 1 > {} && sleep 300".format(fifo)])
+    kcm = psutil.Process(p.pid)
+    # Wait for subprocess to exist
+    helpers.execute("cat {}".format(fifo))
+    clist = c.pool("shared").cpu_list("0")
+    assert kcm.pid in clist.tasks()
+
+    # Send sigterm to kcm
+    kcm.terminate()
     # Wait for kcm process to terminate
     kcm.wait()
     assert kcm.pid not in clist.tasks()


### PR DESCRIPTION
Added two integration test cases:
- send KILL to kcm
- send TERM to kcm

Expected result is that when sending the uncatchable KILL, the config directory is left in an inconsistent state, whereas kcm can now catch TERM and ask the child to exit (by propagating TERM) so that kcm can clean up before exiting. This is the right thing to do in my opinion because it's not safe to remove the kcm pid from the tasks file while the child is still alive.