### PR TITLE
Add ability to taint and label a node with `kcm discover`.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -92,10 +92,11 @@ $ docker run -it --volume=/etc/kcm:/etc/kcm:rw \
 ### `kcm discover`
 
 Advertises the appropriate number of `KCM` [Opaque Integer Resource (OIR)][oir-docs]
-slots on the Kubernetes node. The number of slots advertised is equal to the
-number of cpu lists under the __dataplane__ pool, as determined by examining
-the `KCM` configuration directory. For more information about the config
-format on disk, refer to [the `kcm` configuration directory][doc-config].
+slots, node label and node taint to the Kubernetes node. The number of 
+OIR slots advertised is equal to the number of cpu lists under the 
+__dataplane__ pool, as determined by examining the `KCM` configuration directory. 
+For more information about the config format on disk, refer to 
+the [`kcm` configuration directory][doc-config].
 
 Notes:
 - `kcm discover` is expected to be run as a Kubernetes Pod as it uses
@@ -103,9 +104,11 @@ Notes:
 [Kubernetes python client][k8s-python-client] to get the required Kubernetes
 cluster configuration. The [instructions][discover-op-manual] provided in the
 operator's manual can be used to run the discover Pod.
-- The node will be patched with `pod.alpha.kubernetes.io/opaque-int-resource-kcm'
-OIR.
-- The `KCM` configuration directory should exist and contain the dataplane
+- The node will be patched with `pod.alpha.kubernetes.io/opaque-int-resource-kcm`
+OIR. 
+- The node will be labeled with `"kcm.intel.com/kcm-node": "true"` label. 
+- The node will be tainted with `kcm=true:NoSchedule` taint.
+- The `KCM` configuration directory should exist and contain the dataplane 
 pool to run `kcm discover`.
 
 **Args:**

--- a/tests/unit/test_discover.py
+++ b/tests/unit/test_discover.py
@@ -1,5 +1,6 @@
 from .. import helpers
 from intel import discover
+from kubernetes.client.rest import ApiException as K8sApiException
 import os
 import pytest
 import tempfile
@@ -22,11 +23,10 @@ def test_discover_no_dp():
          "{}".format(os.path.join(conf_dir, "pools", "dataplane"))]
     )
 
-    with patch('intel.discover.patch_k8s_node', MagicMock()):
-        with pytest.raises(KeyError) as err:
-            discover.add_node_oir(conf_dir)
-        expected_msg = "Dataplane pool does not exist"
-        assert err.value.args[0] == expected_msg
+    with pytest.raises(KeyError) as err:
+        discover.add_node_oir(conf_dir)
+    expected_msg = "Dataplane pool does not exist"
+    assert err.value.args[0] == expected_msg
 
 
 def test_discover_no_cldp():
@@ -46,8 +46,96 @@ def test_discover_no_cldp():
                                   "dataplane", "*"))]
     )
 
-    with patch('intel.discover.patch_k8s_node', MagicMock()):
-        with pytest.raises(KeyError) as err:
+    with pytest.raises(KeyError) as err:
+        discover.add_node_oir(conf_dir)
+    expected_msg = "No CPU list in dataplane pool"
+    assert err.value.args[0] == expected_msg
+
+
+class FakeHTTPResponse:
+    def __init__(self, status=None, reason=None, data=None):
+        self.status = status
+        self.reason = reason
+        self.data = data
+
+    def getheaders(self):
+        return {"fakekey": "fakeval"}
+
+
+def get_expected_log_error(err_msg):
+    exp_log_err = err_msg + """: (500)
+Reason: fake reason
+HTTP response headers: {'fakekey': 'fakeval'}
+HTTP response body: fake body
+"""
+    return exp_log_err
+
+
+def test_discover_oir_update_failure(caplog):
+    temp_dir = tempfile.mkdtemp()
+    conf_dir = os.path.join(temp_dir, "discover")
+
+    helpers.execute(
+        "cp",
+        ["-r",
+         helpers.conf_dir("ok"),
+         "{}".format(conf_dir)]
+    )
+
+    fake_http_resp = FakeHTTPResponse(500, "fake reason", "fake body")
+    fake_api_exception = K8sApiException(http_resp=fake_http_resp)
+    with patch('intel.discover.patch_k8s_node_status',
+               MagicMock(side_effect=fake_api_exception)):
+        with pytest.raises(SystemExit):
             discover.add_node_oir(conf_dir)
-        expected_msg = "No CPU list in dataplane pool"
-        assert err.value.args[0] == expected_msg
+        exp_err = "Exception when patching node with OIR"
+        exp_log_err = get_expected_log_error(exp_err)
+        caplog_tuple = caplog.record_tuples
+        assert caplog_tuple[0][2] == exp_log_err
+
+
+def test_discover_add_label_failure(caplog):
+    fake_http_resp = FakeHTTPResponse(500, "fake reason", "fake body")
+    fake_api_exception = K8sApiException(http_resp=fake_http_resp)
+    with patch('intel.discover.patch_k8s_node',
+               MagicMock(side_effect=fake_api_exception)):
+        with pytest.raises(SystemExit):
+            discover.add_node_label()
+        exp_err = "Exception when labeling the node"
+        exp_log_err = get_expected_log_error(exp_err)
+        caplog_tuple = caplog.record_tuples
+        assert caplog_tuple[0][2] == exp_log_err
+
+
+def test_discover_add_taint_failure1(caplog):
+    fake_http_resp = FakeHTTPResponse(500, "fake reason", "fake body")
+    fake_api_exception = K8sApiException(http_resp=fake_http_resp)
+    with patch('intel.discover.get_k8s_node',
+               MagicMock(side_effect=fake_api_exception)):
+        with pytest.raises(SystemExit):
+            discover.add_node_taint()
+        exp_err = "Exception when getting the node obj"
+        exp_log_err = get_expected_log_error(exp_err)
+        caplog_tuple = caplog.record_tuples
+        assert caplog_tuple[0][2] == exp_log_err
+
+
+def test_discover_add_taint_failure2(caplog):
+    fake_node_resp = {
+            "metadata": {
+                "annotations": {
+                }
+            }
+        }
+    fake_http_resp = FakeHTTPResponse(500, "fake reason", "fake body")
+    fake_api_exception = K8sApiException(http_resp=fake_http_resp)
+    with patch('intel.discover.get_k8s_node',
+               MagicMock(return_value=fake_node_resp)), \
+            patch('intel.discover.patch_k8s_node',
+                  MagicMock(side_effect=fake_api_exception)):
+        with pytest.raises(SystemExit):
+            discover.add_node_taint()
+        exp_err = "Exception when tainting the node"
+        exp_log_err = get_expected_log_error(exp_err)
+        caplog_tuple = caplog.record_tuples
+        assert caplog_tuple[0][2] == exp_log_err


### PR DESCRIPTION
Manually tested.