### PR TITLE
Report test coverage automatically on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN pip install -r requirements.txt && chmod +x /kcm/kcm.py
 RUN tox -e lint
 RUN tox -e unit
 RUN tox -e integration
+RUN tox -e coverage
 
 RUN /kcm/kcm.py --help && echo ""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyinstaller>=3.2, <4.0
 kubernetes==1.0.0a4 
 requests>=2.12, <3.0
 pytest-catchlog>=1.2, <1.4
+pytest-cov>=2.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,12 @@ commands =
 
 [testenv:unit]
 commands =
-  py.test -v tests/unit
+  py.test -v --cov --cov-report=annotate --cov-append tests/unit
 
 [testenv:integration]
 commands =
-  py.test -v -x tests/integration
+  py.test -v --cov --cov-report=annotate --cov-append -x tests/integration
+
+[testenv:coverage]
+commands =
+  coverage report --omit='./.tox/*','./tests/*'


### PR DESCRIPTION
Use `pytest-cov` package for test coverage. Example output

```
Name                   Stmts   Miss  Cover
------------------------------------------
intel/__init__.py          0      0   100%
intel/clusterinit.py     115     39    66%
intel/config.py          136      3    98%
intel/describe.py          6      0   100%
intel/discover.py         24     11    54%
intel/init.py             67      0   100%
intel/install.py           8      0   100%
intel/isolate.py          32      2    94%
intel/nodereport.py       78     15    81%
intel/proc.py             47      3    94%
intel/reconcile.py        95     15    84%
intel/third_party.py      52     40    23%
intel/util.py              3      0   100%
kcm.py                    37      5    86%
------------------------------------------
TOTAL                    700    133    81%
```