### PR TITLE
Consolidate pods in kcm cluster-init.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -463,7 +463,8 @@ $ kubectl get NodeReport kcm-02-zzwt7w -o json
 
 Initializes a Kubernetes cluster for the `KCM` software. It runs `KCM`
 subcommands, passed as comma-seperated values to `--kcm-cmd-list`, as
-Kubernetes Pods.
+Kubernetes Pods. By default, it runs all the subcommands and uses all the 
+default options. 
 
 Notes:
 - `kcm cluster-init` is expected to be run as a Kubernetes Pod as it uses
@@ -472,7 +473,7 @@ Notes:
 cluster configuration. The [instructions][cluster-init-op-manual] provided
 in the operator's manual can be used to run the discover Pod.
 - The KCM subcommands, as specified by the value passed for `--kcm-cmd-list`
-are expected to be one of `init`, `discover`, `install`, `reconcile`.
+are expected to be one of `init`, `discover`, `install`, `reconcile`, `nodereport`.
 If `init` subcommand is specified, it expected to be the first command
 in `--kcm-cmd-list`.
 - `--kcm-img-pol` should be one of `Never`, `IfNotPresent`, `Always`.
@@ -516,4 +517,5 @@ $ docker run -it --volume=/etc/kcm:/etc/kcm:rw \
 [link-incluster]: https://github.com/kubernetes-incubator/client-python/blob/master/kubernetes/config/incluster_config.py#L85
 [k8s-python-client]: https://github.com/kubernetes-incubator/client-python
 [discover-op-manual]: operator.md#advertising-kcm-opaque-integer-resource-oir-slots
+[cluster-init-op-manual]: operator.md#prepare-kcm-nodes-by-running-kcm-cluster-init
 [oir-docs]: http://kubernetes.io/docs/user-guide/compute-resources#opaque-integer-resources-alpha-feature

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -9,8 +9,8 @@ Kubernetes >= v1.5.0
 
 ## Setting up the cluster
 
-This section describes the setup required to use the `KCM` software. The steps described below should be followed in 
-the same order.
+This section describes the setup required to use the `KCM` software. The recommended way to prepare Kubernetes nodes 
+for the `KCM` software is to run `kcm cluster-init` as a Pod as described in these [instructions][cluster-init-op-manual]. 
 
 ## Concepts
 
@@ -22,22 +22,11 @@ the same order.
 | Volume         | A volume is a directory (on host file system). In Kubernetes, a volume has the same lifetime as the Pod that uses it. Many types of volumes are supported in Kubernetes. | 
 | `hostPath`       | `hostPath` is a volume type in Kubernetes. It mounts a file or directory from the host file system into the Pod. | 
 
-Notes: 
-- The documentation in this section assumes that the `KCM` configuration directory is `/etc/kcm` and the `kcm`
-binary is installed on the host under `/opt/bin`.
-- In all the pod templates used in this section, the name of container image used is `kcm`. It is expected that the 
-`kcm` container image is built and cached locally in the host. The `image` field will require modification if the 
-container image is hosted remotely (e.g., in https://hub.docker.com/). If the `image` field is modified to use a 
-remotely hosted container image, the following should be removed from each of the pod template:
-
-```yml
-imagePullPolicy: "Never"
-```
-
 ### Prepare `KCM` nodes by running `kcm cluster-init`. 
 `KCM` nodes can be prepared by using [`kcm cluster-init`][kcm-cluster-init] subcommand. The subcommand is expected to 
 be run as a pod. The [kcm-cluster-init-pod template][cluster-init-template] can be used to run `kcm cluster-init` on a 
-Kubernetes cluster. When run on a Kubernetes cluster, the Pod spawns several other Pods in order to prepare the nodes.
+Kubernetes cluster. When run on a Kubernetes cluster, the Pod spawns two Pods per node at most in order to prepare 
+each node.
 
 The only value that requires change in the [kcm-cluster-init-pod template][kcm-cluster-init] is the `args` field, 
 which can be modified to pass different options. 
@@ -65,9 +54,22 @@ The above command prepares all the nodes in the Kubernetes cluster for the `KCM`
 The above command prepares nodes "node1", "node2" and "node3" but only runs the `kcm init` and `kcm discover` 
 subcommands on each of those nodes. 
 
-For more details on the options provided by `kcm cluster-init`, see this [description][kcm-cluster-init]. 
+For more details on the options provided by `kcm cluster-init`, see this [description][kcm-cluster-init].
 
 ### Prepare `KCM` nodes by running each `KCM` subcommand as a Pod. 
+
+Notes:
+- The subcommands described below should be run in the same order. 
+- The documentation in this section assumes that the `KCM` configuration directory is `/etc/kcm` and the `kcm`
+binary is installed on the host under `/opt/bin`.
+- In all the pod templates used in this section, the name of container image used is `kcm`. It is expected that the 
+`kcm` container image is built and cached locally in the host. The `image` field will require modification if the 
+container image is hosted remotely (e.g., in https://hub.docker.com/). If the `image` field is modified to use a 
+remotely hosted container image, the following should be removed from each of the pod template:
+
+```yml
+imagePullPolicy: "Never"
+```
 #### Run `kcm init`
 The `KCM` nodes in the kubernetes cluster should be initialized in order to be used with the KCM software using 
 [`kcm-init`][kcm-init]. To initialize the `KCM` nodes, the [kcm-init-pod template][init-template] can be used. 
@@ -223,3 +225,4 @@ one OIR. This restricts the number of pods that can land on a Kubernetes node to
 [isolate-template]: ../resources/pods/kcm-isolate-pod.yaml
 [cluster-init-template]: ../resources/pods/kcm-cluster-init-pod.yaml
 [oir-docs]: http://kubernetes.io/docs/user-guide/compute-resources#opaque-integer-resources-alpha-feature
+[cluster-init-op-manual]: #prepare-kcm-nodes-by-running-kcm-cluster-init

--- a/tests/unit/test_clusterinit.py
+++ b/tests/unit/test_clusterinit.py
@@ -97,19 +97,26 @@ class FakeHTTPResponse:
         return {"fakekey": "fakeval"}
 
 
+def get_expected_log_error(err_msg):
+    exp_log_err = err_msg + """: (500)
+Reason: fake reason
+HTTP response headers: {'fakekey': 'fakeval'}
+HTTP response body: fake body
+"""
+    return exp_log_err
+
+
 def test_clusterinit_run_cmd_pods_init_failure(caplog):
     fake_http_resp = FakeHTTPResponse(500, "fake reason", "fake body")
     fake_api_exception = K8sApiException(http_resp=fake_http_resp)
     with patch('intel.clusterinit.create_k8s_pod',
                MagicMock(side_effect=fake_api_exception)):
         with pytest.raises(SystemExit):
-            clusterinit.run_pods("init", "fake_img", "Never", "fake-conf-dir",
-                                 "fake-install-dir", "2", "2", ["fakenode"])
-        exp_log_err = """Exception when creating init pod: (500)
-Reason: fake reason
-HTTP response headers: {'fakekey': 'fakeval'}
-HTTP response body: fake body
-"""
+            clusterinit.run_pods(None, ["init"], "fake_img",
+                                 "Never", "fake-conf-dir", "fake-install-dir",
+                                 "2", "2", ["fakenode"])
+        exp_err = "Exception when creating pod for ['init'] command(s)"
+        exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
         assert caplog_tuple[1][2] == exp_log_err
 
@@ -120,14 +127,11 @@ def test_clusterinit_run_cmd_pods_discover_failure(caplog):
     with patch('intel.clusterinit.create_k8s_pod',
                MagicMock(side_effect=fake_api_exception)):
         with pytest.raises(SystemExit):
-            clusterinit.run_pods("discover", "fake_img", "Never",
+            clusterinit.run_pods(None, ["discover"], "fake_img", "Never",
                                  "fake-conf-dir", "fake-install-dir", "2",
                                  "2", ["fakenode"])
-        exp_log_err = """Exception when creating discover pod: (500)
-Reason: fake reason
-HTTP response headers: {'fakekey': 'fakeval'}
-HTTP response body: fake body
-"""
+        exp_err = "Exception when creating pod for ['discover'] command(s)"
+        exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
         assert caplog_tuple[1][2] == exp_log_err
 
@@ -138,14 +142,11 @@ def test_clusterinit_run_cmd_pods_install_failure(caplog):
     with patch('intel.clusterinit.create_k8s_pod',
                MagicMock(side_effect=fake_api_exception)):
         with pytest.raises(SystemExit):
-            clusterinit.run_pods("install", "fake_img", "Never",
+            clusterinit.run_pods(None, ["install"], "fake_img", "Never",
                                  "fake-conf-dir", "fake-install-dir", "2",
                                  "2", ["fakenode"])
-        exp_log_err = """Exception when creating install pod: (500)
-Reason: fake reason
-HTTP response headers: {'fakekey': 'fakeval'}
-HTTP response body: fake body
-"""
+        exp_err = "Exception when creating pod for ['install'] command(s)"
+        exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
         assert caplog_tuple[1][2] == exp_log_err
 
@@ -156,14 +157,26 @@ def test_clusterinit_run_cmd_pods_reconcile_failure(caplog):
     with patch('intel.clusterinit.create_k8s_pod',
                MagicMock(side_effect=fake_api_exception)):
         with pytest.raises(SystemExit):
-            clusterinit.run_pods("reconcile", "fake_img", "Never",
+            clusterinit.run_pods(["reconcile"], None, "fake_img", "Never",
                                  "fake-conf-dir", "fake-install-dir", "2",
                                  "2", ["fakenode"])
-        exp_log_err = """Exception when creating reconcile pod: (500)
-Reason: fake reason
-HTTP response headers: {'fakekey': 'fakeval'}
-HTTP response body: fake body
-"""
+        exp_err = "Exception when creating pod for ['reconcile'] command(s)"
+        exp_log_err = get_expected_log_error(exp_err)
+        caplog_tuple = caplog.record_tuples
+        assert caplog_tuple[1][2] == exp_log_err
+
+
+def test_clusterinit_run_cmd_pods_nodereport_failure(caplog):
+    fake_http_resp = FakeHTTPResponse(500, "fake reason", "fake body")
+    fake_api_exception = K8sApiException(http_resp=fake_http_resp)
+    with patch('intel.clusterinit.create_k8s_pod',
+               MagicMock(side_effect=fake_api_exception)):
+        with pytest.raises(SystemExit):
+            clusterinit.run_pods(["nodereport"], None, "fake_img", "Never",
+                                 "fake-conf-dir", "fake-install-dir", "2",
+                                 "2", ["fakenode"])
+        exp_err = "Exception when creating pod for ['nodereport'] command(s)"
+        exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
         assert caplog_tuple[1][2] == exp_log_err
 


### PR DESCRIPTION
- Runs a max of two pods per node now. One for long-running daemons and one for one-shot jobs.
- Manually tested.