### PR TITLE
Isolate reconcile and node-report daemons.

### DIFF
--- a/intel/clusterinit.py
+++ b/intel/clusterinit.py
@@ -99,9 +99,9 @@ def run_cmd_pods(cmd_list, cmd_init_list, kcm_img, kcm_img_pol, conf_dir,
         for cmd in cmd_list:
             args = ""
             if cmd == "reconcile":
-                args = "/kcm/kcm.py reconcile --interval=5 --publish"
+                args = "/kcm/kcm.py isolate --pool=infra /kcm/kcm.py -- reconcile --interval=5 --publish"  # noqa: E501
             elif cmd == "nodereport":
-                args = "/kcm/kcm.py node-report --interval=5 --publish"
+                args = "/kcm/kcm.py isolate --pool=infra /kcm/kcm.py -- node-report --interval=5 --publish"  # noqa: E501
 
             update_pod_with_container(pod, cmd, kcm_img, kcm_img_pol, args)
     elif cmd_init_list:

--- a/resources/pods/kcm-nodereport-daemonset.yaml
+++ b/resources/pods/kcm-nodereport-daemonset.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - args:
-        - /kcm/kcm.py node-report --conf-dir=/etc/kcm --interval=$KCM_NODE_REPORT_SLEEP_TIME --publish
+        - /kcm/kcm.py isolate --pool=infra /kcm/kcm.py -- node-report --interval=$KCM_NODE_REPORT_SLEEP_TIME --publish
         command:
         - "/bin/bash"
         - "-c"

--- a/resources/pods/kcm-reconcile-daemonset.yaml
+++ b/resources/pods/kcm-reconcile-daemonset.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - args:
-        - /kcm/kcm.py reconcile --conf-dir=/etc/kcm --interval=$KCM_RECONCILE_SLEEP_TIME --publish
+        - /kcm/kcm.py isolate --pool=infra /kcm/kcm.py reconcile --interval=$KCM_RECONCILE_SLEEP_TIME --publish
         command:
         - "/bin/bash"
         - "-c"


### PR DESCRIPTION
Use `kcm isolate` to constrain `kcm reconcile` and `kcm node-report` to the "infra" pool.

Example node report after running cluster-init (only kcm daemon pod still running):

```
$ kubectl get nodereport kcm-02-zzwt7w -o json | jq .report.description.pools.infra
{
  "cpuLists": {
    "0,1,2,3,4,5": {
      "cpus": "0,1,2,3,4,5",
      "tasks": [
        14304,
        14404
      ]
    }
  },
  "exclusive": false,
  "name": "infra"
}
```