### PR TITLE
KCM all in one manifest

### DIFF
--- a/resources/pods/kcm-feature-daemonset.yaml
+++ b/resources/pods/kcm-feature-daemonset.yaml
@@ -1,0 +1,188 @@
+# Intel License for KCM (version January 2017)
+#
+# Copyright (c) 2017 Intel Corporation.
+#
+# Use.  You may use the software (the “Software”), without modification,
+# provided the following conditions are met:
+#
+# * Neither the name of Intel nor the names of its suppliers may be used to
+#   endorse or promote products derived from this Software without specific
+#   prior written permission.
+# * No reverse engineering, decompilation, or disassembly of this Software
+#   is permitted.
+#
+# Limited patent license.  Intel grants you a world-wide, royalty-free,
+# non-exclusive license under patents it now or hereafter owns or controls to
+# make, have made, use, import, offer to sell and sell (“Utilize”) this
+# Software, but solely to the extent that any such patent is necessary to
+# Utilize the Software alone. The patent license shall not apply to any
+# combinations which include this software.  No hardware per se is licensed
+# hereunder.
+#
+# Third party and other Intel programs.  “Third Party Programs” are the files
+# listed in the “third-party-programs.txt” text file that is included with the
+# Software and may include Intel programs under separate license terms. Third
+# Party Programs, even if included with the distribution of the Materials, are
+# governed by separate license terms and those license terms solely govern your
+# use of those programs.
+#
+# DISCLAIMER.  THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT ARE
+# DISCLAIMED. THIS SOFTWARE IS NOT INTENDED NOR AUTHORIZED FOR USE IN SYSTEMS
+# OR APPLICATIONS WHERE FAILURE OF THE SOFTWARE MAY CAUSE PERSONAL INJURY OR
+# DEATH.
+#
+# LIMITATION OF LIABILITY. IN NO EVENT WILL INTEL BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. YOU AGREE TO
+# INDEMNIFIY AND HOLD INTEL HARMLESS AGAINST ANY CLAIMS AND EXPENSES RESULTING
+# FROM YOUR USE OR UNAUTHORIZED USE OF THE SOFTWARE.
+#
+# No support.  Intel may make changes to the Software, at any time without
+# notice, and is not obligated to support, update or provide training for the
+# Software.
+#
+# Termination. Intel may terminate your right to use the Software in the event
+# of your breach of this Agreement and you fail to cure the breach within a
+# reasonable period of time.
+#
+# Feedback.  Should you provide Intel with comments, modifications,
+# corrections, enhancements or other input (“Feedback”) related to the Software
+# Intel will be free to use, disclose, reproduce, license or otherwise
+# distribute or exploit the Feedback in its sole discretion without any
+# obligations or restrictions of any kind, including without limitation,
+# intellectual property rights or licensing obligations.
+#
+# Compliance with laws.  You agree to comply with all relevant laws and
+# regulations governing your use, transfer, import or export (or prohibition
+# thereof) of the Software.
+#
+# Governing law.  All disputes will be governed by the laws of the United
+# States of America and the State of Delaware without reference to conflict of
+# law principles and subject to the exclusive jurisdiction of the state or
+# federal courts sitting in the State of Delaware, and each party agrees that
+# it submits to the personal jurisdiction and venue of those courts and waives
+# any objections. The United Nations Convention on Contracts for the
+# International Sale of Goods (1980) is specifically excluded and will not
+# apply to the Software.
+#
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: kcm-feature
+  name: kcm-feature
+spec:
+  template:
+    metadata:
+      labels:
+        app: kcm-feature
+      annotations:
+        pod.beta.kubernetes.io/init-containers: '[
+          {
+            "name": "kcm-init",
+            "image": "kcm:v0.1.1",
+            "command": ["/bin/bash","-c"],
+            "args": ["/kcm/kcm.py init --conf-dir=/etc/kcm --num-dp-cores=$NUM_DP_CORES --num-cp-cores=$NUM_CP_CORES"],
+            "imagePullPolicy": "IfNotPresent",
+            "volumeMounts": [
+              { "name": "kcm-conf-dir", "mountPath": "/etc/kcm" }
+            ],
+            "env": [
+              { "name": "NUM_DP_CORES", "value": "2" },
+              { "name": "NUM_CP_CORES", "value": "2" }
+            ]
+          },
+          {
+            "name": "kcm-install",
+            "image": "kcm:v0.1.1",
+            "command": ["/bin/bash","-c"],
+            "args": ["/kcm/kcm.py install --install-dir=/opt/bin"],
+            "imagePullPolicy": "IfNotPresent",
+            "volumeMounts": [
+              { "name": "kcm-install-dir", "mountPath": "/opt/bin" }
+            ]
+          },
+          {
+            "name": "kcm-discover",
+            "image": "kcm:v0.1.1",
+            "command": ["/bin/bash","-c"],
+            "args": ["/kcm/kcm.py discover --conf-dir=/etc/kcm"],
+            "imagePullPolicy": "IfNotPresent",
+            "volumeMounts": [
+              { "name": "kcm-conf-dir", "mountPath": "/etc/kcm" }
+            ],
+            "env": [
+              { "name": "NODE_NAME", "valueFrom": { "fieldRef": { "apiVersion": "v1", "fieldPath": "spec.nodeName" } } }
+            ]
+          }
+        ]'
+    spec:
+      nodeSelector:
+        kcm: enabled
+      containers:
+      - name: kcm-nodereport
+        image: kcm:v0.1.1
+        args:
+        - /kcm/kcm.py isolate --pool=infra /kcm/kcm.py -- node-report --interval=$KCM_NODE_REPORT_SLEEP_TIME --publish
+        command:
+        - "/bin/bash"
+        - "-c"
+        env:
+        - name: KCM_NODE_REPORT_SLEEP_TIME
+          # Change this to modify the sleep interval between consecutive
+          # kcm node report runs. The value is specified in seconds.
+          value: '10'
+        - name: KCM_PROC_FS
+          value: "/host/proc"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - mountPath: "/host/proc"
+          name: host-proc
+          readOnly: true
+        - mountPath: "/etc/kcm"
+          name: kcm-conf-dir
+      - name: kcm-reconcile
+        image: kcm:v0.1.1
+        args:
+        - /kcm/kcm.py isolate --pool=infra /kcm/kcm.py -- reconcile --interval=$KCM_RECONCILE_SLEEP_TIME --publish
+        command:
+        - "/bin/bash"
+        - "-c"
+        env:
+        - name: KCM_RECONCILE_SLEEP_TIME
+          # Change this to modify the sleep interval between consecutive
+          # kcm reconcile runs. The value is specified in seconds.
+          value: '10'
+        - name: KCM_PROC_FS
+          value: "/host/proc"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - mountPath: "/host/proc"
+          name: host-proc
+          readOnly: true
+        - mountPath: "/etc/kcm"
+          name: kcm-conf-dir
+      volumes:
+      - hostPath:
+          path: "/proc"
+        name: host-proc
+      - hostPath:
+          # Change this to modify the KCM config dir in the host file system.
+          path: "/etc/kcm"
+        name: kcm-conf-dir
+      - hostPath:
+      # Change this to modify the KCM installation dir in the host file system.
+          path: "/opt/bin"
+        name: kcm-install-dir


### PR DESCRIPTION
This is the proposal for manifest that can replace `cluster-init` sub-command.

Using node label `kcm=enabled` user can deploy kcm solution on any node.
DaemonSet pod has:
- 3 InitContainers (*init,install, discover*)
- 2 Containers (*node-report, reconcile*)
 

Tested locally on Vagrant VM's
