### PR TITLE
Jenkins stub target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ all: docker
 
 version=v0.2.0
 
+# TODO: This target should be changed, when e2e tests will be ready and test
+# entrypoint will be defined.
+jenkins: docker
+
 docker:
 	docker build --no-cache -t kcm:$(version) .
 	@echo ""


### PR DESCRIPTION
This PR enables Jenkins support for KCM. Currently it is pointing to docker target, but it should be changed when e2e tests entrypoint will be defined