### PR TITLE
Remove host limit on post_deploy playbook

### DIFF
--- a/terraform/scripts/ansible_provisioner.sh
+++ b/terraform/scripts/ansible_provisioner.sh
@@ -30,5 +30,5 @@ echo ""
 echo "============================"
 echo "Running post deploy"
 echo "============================"
-ansible-playbook --connection=ssh --timeout=30 --limit=all --inventory-file=./mvp_inventory/ --sudo ${ansible_verbosity} post_deploy.yml
+ansible-playbook --connection=ssh --timeout=30 --inventory-file=./mvp_inventory/ --sudo ${ansible_verbosity} post_deploy.yml
 popd


### PR DESCRIPTION
`--limit=all` limited host list for ansible playbook, that resulted in `get_kubectl` role to be skipped