### PR TITLE
Increase number of CPUs in default Terraform configuration

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -63,7 +63,7 @@ variable "k8s_minion_config" {
   description = "minion nodes configuration."
 
   default = {
-    cpu    = "4"
+    cpu    = "8"
     mem    = "2048"
     flavor = "m4.4xlarge"
   }


### PR DESCRIPTION
Our local e2e environment provide too small number of vCPUs to meet our default KCM values. This PR is standardize our local e2e environment configuration with KCM defaults.  