### PR TITLE
Support for TPR name not conforming with LDH

### DIFF
--- a/intel/third_party.py
+++ b/intel/third_party.py
@@ -75,6 +75,7 @@ import json
 from kubernetes.client.rest import ApiException as K8sApiException
 import datetime
 import logging
+import re
 import time
 
 # Example usage:
@@ -171,7 +172,7 @@ class ThirdPartyResource:
 
         self.api = api
         self.resource_type = resource_type
-        self.name = name
+        self.name = ldh_convert_check(name)
         self.namespace = namespace
 
         self.body = {
@@ -180,7 +181,7 @@ class ThirdPartyResource:
                 self.resource_type.type_version
             ]),
             "kind": self.resource_type.kind_name,
-            "metadata": {"name": name}
+            "metadata": {"name": self.name}
         }
 
         self.header_params = {
@@ -234,3 +235,15 @@ class ThirdPartyResource:
 
             self.remove()
             self.create()
+
+
+def ldh_convert_check(name):
+    name_con = re.sub(r'[^-a-z0-9]', '-', name.lower())
+    logging.info("Converted \"{}\" to \"{}\" for"
+                 " TPR name".format(name, name_con))
+    if not re.fullmatch('[a-z0-9]([-a-z0-9]*[a-z0-9])?', name_con):
+        logging.error("Cant create valid TPR name using "
+                      "\"{}\" - must match regex "
+                      "[a-z0-9]([-a-z0-9]*[a-z0-9])?".format(name_con))
+        exit(1)
+    return name_con

--- a/tests/unit/test_third_party.py
+++ b/tests/unit/test_third_party.py
@@ -1,0 +1,122 @@
+# Intel License for KCM (version January 2017)
+#
+# Copyright (c) 2017 Intel Corporation.
+#
+# Use.  You may use the software (the "Software"), without modification,
+# provided the following conditions are met:
+#
+# * Neither the name of Intel nor the names of its suppliers may be used to
+#   endorse or promote products derived from this Software without specific
+#   prior written permission.
+# * No reverse engineering, decompilation, or disassembly of this Software
+#   is permitted.
+#
+# Limited patent license.  Intel grants you a world-wide, royalty-free,
+# non-exclusive license under patents it now or hereafter owns or controls to
+# make, have made, use, import, offer to sell and sell ("Utilize") this
+# Software, but solely to the extent that any such patent is necessary to
+# Utilize the Software alone. The patent license shall not apply to any
+# combinations which include this software.  No hardware per se is licensed
+# hereunder.
+#
+# Third party and other Intel programs.  "Third Party Programs" are the files
+# listed in the "third-party-programs.txt" text file that is included with the
+# Software and may include Intel programs under separate license terms. Third
+# Party Programs, even if included with the distribution of the Materials, are
+# governed by separate license terms and those license terms solely govern your
+# use of those programs.
+#
+# DISCLAIMER.  THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT ARE
+# DISCLAIMED. THIS SOFTWARE IS NOT INTENDED NOR AUTHORIZED FOR USE IN SYSTEMS
+# OR APPLICATIONS WHERE FAILURE OF THE SOFTWARE MAY CAUSE PERSONAL INJURY OR
+# DEATH.
+#
+# LIMITATION OF LIABILITY. IN NO EVENT WILL INTEL BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. YOU AGREE TO
+# INDEMNIFIY AND HOLD INTEL HARMLESS AGAINST ANY CLAIMS AND EXPENSES RESULTING
+# FROM YOUR USE OR UNAUTHORIZED USE OF THE SOFTWARE.
+#
+# No support.  Intel may make changes to the Software, at any time without
+# notice, and is not obligated to support, update or provide training for the
+# Software.
+#
+# Termination. Intel may terminate your right to use the Software in the event
+# of your breach of this Agreement and you fail to cure the breach within a
+# reasonable period of time.
+#
+# Feedback.  Should you provide Intel with comments, modifications,
+# corrections, enhancements or other input ("Feedback") related to the Software
+# Intel will be free to use, disclose, reproduce, license or otherwise
+# distribute or exploit the Feedback in its sole discretion without any
+# obligations or restrictions of any kind, including without limitation,
+# intellectual property rights or licensing obligations.
+#
+# Compliance with laws.  You agree to comply with all relevant laws and
+# regulations governing your use, transfer, import or export (or prohibition
+# thereof) of the Software.
+#
+# Governing law.  All disputes will be governed by the laws of the United
+# States of America and the State of Delaware without reference to conflict of
+# law principles and subject to the exclusive jurisdiction of the state or
+# federal courts sitting in the State of Delaware, and each party agrees that
+# it submits to the personal jurisdiction and venue of those courts and waives
+# any objections. The United Nations Convention on Contracts for the
+# International Sale of Goods (1980) is specifically excluded and will not
+# apply to the Software.
+
+from intel import third_party
+import pytest
+
+
+def test_ldh_parser_success():
+
+    original_node_names = [
+        "node-123",
+        "node-123.45",
+        "Node.Master-89",
+        "123-master-NODE",
+        "192.167-100-2.NODE",
+        "MINION.1@10.12.56.78",
+        "MINION.1@.#10.12.56.78",
+        "Compute---1@10.12.56.78"
+    ]
+
+    expected_node_names = [
+        "node-123",
+        "node-123-45",
+        "node-master-89",
+        "123-master-node",
+        "192-167-100-2-node",
+        "minion-1-10-12-56-78",
+        "minion-1---10-12-56-78",
+        "compute---1-10-12-56-78"
+    ]
+
+    retrieved_node_names = []
+
+    for name in original_node_names:
+        retrieved_node_names.append(third_party.ldh_convert_check(name))
+
+    assert expected_node_names == retrieved_node_names
+
+
+def test_ldh_parser_fail():
+
+    original_invalid_node_names = [
+        "node-123-",
+        "node-123.45@",
+        "$Node.Master-89",
+        ".123-master-NODE",
+        "@192.167-100-2-NODE",
+    ]
+
+    for name in original_invalid_node_names:
+        with pytest.raises(SystemExit):
+            third_party.ldh_convert_check(name)


### PR DESCRIPTION
TPR are named after node names. If node name does not follow LDH convention (i.e. Node name is IPv4 address), creating TPR raises kubernetes API exception.

In current approach any character not in [-a-z0-9] is replaced with "-", then check is made if the TPR report name is valid.

Testes locally with VM's based k8s cluster