### PR TITLE
Add "--pull-secret" parameter to cluster-init

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,7 +84,7 @@ Usage:
   kcm cluster-init (--host-list=<list>|--all-hosts) [--kcm-cmd-list=<list>]
                    [--kcm-img=<img>] [--kcm-img-pol=<pol>] [--conf-dir=<dir>]
                    [--install-dir=<dir>] [--num-dp-cores=<num>]
-                   [--num-cp-cores=<num>]
+                   [--num-cp-cores=<num>] [--pull-secret=<name>]
   kcm init [--conf-dir=<dir>] [--num-dp-cores=<num>] [--num-cp-cores=<num>]
   kcm discover [--conf-dir=<dir>]
   kcm describe [--conf-dir=<dir>]
@@ -116,6 +116,8 @@ Options:
   --pool=<pool>         Pool name: either infra, controlplane or dataplane.
   --publish             Whether to publish reports to the Kubernetes
                         API server.
+  --pull-secret=<name>  Name of secret used for pulling Docker images from
+                        restricted Docker registry.
   --no-affinity         Do not set cpu affinity before forking the child
                         command. In this mode the user program is responsible
                         for reading the `KCM_CPUS_ASSIGNED` environment

--- a/docs/html/docs/cli.html
+++ b/docs/html/docs/cli.html
@@ -101,6 +101,8 @@ Options:
   --pool=&lt;pool&gt;         Pool name: either infra, controlplane or dataplane.
   --publish             Whether to publish reports to the Kubernetes
                         API server.
+  --pull-secret=<name>  Name of secret used for pulling Docker images from
+                        restricted Docker registry.
   --no-affinity         Do not set cpu affinity before forking the child
                         command. In this mode the user program is responsible
                         for reading the `KCM_CPUS_ASSIGNED` environment

--- a/kcm.py
+++ b/kcm.py
@@ -81,7 +81,7 @@ Usage:
   kcm cluster-init (--host-list=<list>|--all-hosts) [--kcm-cmd-list=<list>]
                    [--kcm-img=<img>] [--kcm-img-pol=<pol>] [--conf-dir=<dir>]
                    [--install-dir=<dir>] [--num-dp-cores=<num>]
-                   [--num-cp-cores=<num>]
+                   [--num-cp-cores=<num>] [--pull-secret=<name>]
   kcm init [--conf-dir=<dir>] [--num-dp-cores=<num>] [--num-cp-cores=<num>]
   kcm discover [--conf-dir=<dir>]
   kcm describe [--conf-dir=<dir>]
@@ -113,6 +113,8 @@ Options:
   --pool=<pool>         Pool name: either infra, controlplane or dataplane.
   --publish             Whether to publish reports to the Kubernetes
                         API server.
+  --pull-secret=<name>  Name of secret used for pulling Docker images from
+                        restricted Docker registry.
   --no-affinity         Do not set cpu affinity before forking the child
                         command. In this mode the user program is responsible
                         for reading the `KCM_CPUS_ASSIGNED` environment
@@ -137,7 +139,7 @@ def main():
                                  args["--kcm-cmd-list"], args["--kcm-img"],
                                  args["--kcm-img-pol"], args["--conf-dir"],
                                  args["--install-dir"], args["--num-dp-cores"],
-                                 args["--num-cp-cores"])
+                                 args["--num-cp-cores"], args["--pull-secret"])
         return
     if args["init"]:
         init.init(args["--conf-dir"],

--- a/tests/integration/test_kcm_help.py
+++ b/tests/integration/test_kcm_help.py
@@ -84,7 +84,7 @@ Usage:
   kcm cluster-init (--host-list=<list>|--all-hosts) [--kcm-cmd-list=<list>]
                    [--kcm-img=<img>] [--kcm-img-pol=<pol>] [--conf-dir=<dir>]
                    [--install-dir=<dir>] [--num-dp-cores=<num>]
-                   [--num-cp-cores=<num>]
+                   [--num-cp-cores=<num>] [--pull-secret=<name>]
   kcm init [--conf-dir=<dir>] [--num-dp-cores=<num>] [--num-cp-cores=<num>]
   kcm discover [--conf-dir=<dir>]
   kcm describe [--conf-dir=<dir>]
@@ -116,6 +116,8 @@ Options:
   --pool=<pool>         Pool name: either infra, controlplane or dataplane.
   --publish             Whether to publish reports to the Kubernetes
                         API server.
+  --pull-secret=<name>  Name of secret used for pulling Docker images from
+                        restricted Docker registry.
   --no-affinity         Do not set cpu affinity before forking the child
                         command. In this mode the user program is responsible
                         for reading the `KCM_CPUS_ASSIGNED` environment

--- a/tests/unit/test_clusterinit.py
+++ b/tests/unit/test_clusterinit.py
@@ -83,7 +83,7 @@ def test_clusterinit_invalid_cmd_list_failure1():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "fakecmd1, fakecmd2",
                                  "kcm", "Never", "/etc/kcm", "/opt/bin",
-                                 "4", "2")
+                                 "4", "2", "")
     expected_err_msg = ("KCM command should be one of "
                         "['init', 'discover', 'install', 'reconcile', "
                         "'nodereport']")
@@ -94,7 +94,7 @@ def test_clusterinit_invalid_cmd_list_failure2():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "fakecmd1, init",
                                  "kcm", "Never", "/etc/kcm", "/opt/bin",
-                                 "4", "2")
+                                 "4", "2", "")
     expected_err_msg = ("KCM command should be one of "
                         "['init', 'discover', 'install', 'reconcile', "
                         "'nodereport']")
@@ -105,7 +105,7 @@ def test_clusterinit_invalid_cmd_list_failure3():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "init, fakecmd1, install",
                                  "kcm", "Never", "/etc/kcm", "/opt/bin",
-                                 "4", "2")
+                                 "4", "2", "")
     expected_err_msg = ("KCM command should be one of "
                         "['init', 'discover', 'install', 'reconcile', "
                         "'nodereport']")
@@ -116,7 +116,7 @@ def test_clusterinit_invalid_cmd_list_failure4():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "discover, init",
                                  "kcm", "Never", "/etc/kcm", "/opt/bin",
-                                 "4", "2")
+                                 "4", "2", "")
     expected_err_msg = "init command should be run and listed first."
     assert err.value.args[0] == expected_err_msg
 
@@ -124,7 +124,7 @@ def test_clusterinit_invalid_cmd_list_failure4():
 def test_clusterinit_invalid_image_pol():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "init", "kcm", "fakepol1",
-                                 "/etc/kcm", "/opt/bin", "4", "2")
+                                 "/etc/kcm", "/opt/bin", "4", "2", "")
     expected_err_msg = ('Image pull policy should be one of '
                         '[\'Never\', \'IfNotPresent\', \'Always\']')
     assert err.value.args[0] == expected_err_msg
@@ -133,7 +133,7 @@ def test_clusterinit_invalid_image_pol():
 def test_clusterinit_invalid_dp_cores_failure1():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "init", "kcm", "Never",
-                                 "/etc/kcm", "/opt/bin", "-1", "2")
+                                 "/etc/kcm", "/opt/bin", "-1", "2", "")
     expected_err_msg = "num_dp_cores cores should be a positive integer."
     assert err.value.args[0] == expected_err_msg
 
@@ -141,7 +141,7 @@ def test_clusterinit_invalid_dp_cores_failure1():
 def test_clusterinit_invalid_dp_cores_failure2():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "init", "kcm", "Never",
-                                 "/etc/kcm", "/opt/bin", "3.5", "2")
+                                 "/etc/kcm", "/opt/bin", "3.5", "2", "")
     expected_err_msg = "num_dp_cores cores should be a positive integer."
     assert err.value.args[0] == expected_err_msg
 
@@ -149,7 +149,7 @@ def test_clusterinit_invalid_dp_cores_failure2():
 def test_clusterinit_invalid_cp_cores_failure1():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "init", "kcm", "Never",
-                                 "/etc/kcm", "/opt/bin", "1", "2.5")
+                                 "/etc/kcm", "/opt/bin", "1", "2.5", "")
     expected_err_msg = "num_cp_cores cores should be a positive integer."
     assert err.value.args[0] == expected_err_msg
 
@@ -157,7 +157,7 @@ def test_clusterinit_invalid_cp_cores_failure1():
 def test_clusterinit_invalid_cp_cores_failure2():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "init", "kcm", "Never",
-                                 "/etc/kcm", "/opt/bin", "1", "10.5")
+                                 "/etc/kcm", "/opt/bin", "1", "10.5", "")
     expected_err_msg = "num_cp_cores cores should be a positive integer."
     assert err.value.args[0] == expected_err_msg
 
@@ -189,7 +189,7 @@ def test_clusterinit_run_cmd_pods_init_failure(caplog):
         with pytest.raises(SystemExit):
             clusterinit.run_pods(None, ["init"], "fake_img",
                                  "Never", "fake-conf-dir", "fake-install-dir",
-                                 "2", "2", ["fakenode"])
+                                 "2", "2", ["fakenode"], "")
         exp_err = "Exception when creating pod for ['init'] command(s)"
         exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
@@ -204,7 +204,7 @@ def test_clusterinit_run_cmd_pods_discover_failure(caplog):
         with pytest.raises(SystemExit):
             clusterinit.run_pods(None, ["discover"], "fake_img", "Never",
                                  "fake-conf-dir", "fake-install-dir", "2",
-                                 "2", ["fakenode"])
+                                 "2", ["fakenode"], "")
         exp_err = "Exception when creating pod for ['discover'] command(s)"
         exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
@@ -219,7 +219,7 @@ def test_clusterinit_run_cmd_pods_install_failure(caplog):
         with pytest.raises(SystemExit):
             clusterinit.run_pods(None, ["install"], "fake_img", "Never",
                                  "fake-conf-dir", "fake-install-dir", "2",
-                                 "2", ["fakenode"])
+                                 "2", ["fakenode"], "")
         exp_err = "Exception when creating pod for ['install'] command(s)"
         exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
@@ -234,7 +234,7 @@ def test_clusterinit_run_cmd_pods_reconcile_failure(caplog):
         with pytest.raises(SystemExit):
             clusterinit.run_pods(["reconcile"], None, "fake_img", "Never",
                                  "fake-conf-dir", "fake-install-dir", "2",
-                                 "2", ["fakenode"])
+                                 "2", ["fakenode"], "")
         exp_err = "Exception when creating pod for ['reconcile'] command(s)"
         exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
@@ -249,7 +249,7 @@ def test_clusterinit_run_cmd_pods_nodereport_failure(caplog):
         with pytest.raises(SystemExit):
             clusterinit.run_pods(["nodereport"], None, "fake_img", "Never",
                                  "fake-conf-dir", "fake-install-dir", "2",
-                                 "2", ["fakenode"])
+                                 "2", ["fakenode"], "")
         exp_err = "Exception when creating pod for ['nodereport'] command(s)"
         exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
@@ -280,6 +280,39 @@ def test_clusterinit_node_list_host_list():
     fake_node_list = "fakenode1, fakenode2, fakenode3"
     node_list = clusterinit.get_kcm_node_list(fake_node_list, False)
     assert node_list == ["fakenode1", "fakenode2", "fakenode3"]
+
+
+def test_clusterinit_pass_pull_secrets():
+    mock = MagicMock()
+    with patch('intel.k8s.client_from_config', MagicMock(return_value=mock)):
+        with patch('intel.clusterinit.wait_for_pod_phase',
+                   MagicMock(return_value=True)):
+            clusterinit.cluster_init("fakenode1", False,
+                                     "init, discover, install",
+                                     "kcm", "Never", "/etc/kcm", "/opt/bin",
+                                     "4", "2", "supersecret")
+            called_methods = mock.method_calls
+            params = called_methods[0][1]
+            pod_spec = params[1]
+            assert "imagePullSecrets" in pod_spec["spec"]
+            secrets = pod_spec["spec"]["imagePullSecrets"]
+            assert len(secrets) == 1
+            assert secrets[0]["name"] == "supersecret"
+
+
+def test_clusterinit_dont_pass_pull_secrets():
+    mock = MagicMock()
+    with patch('intel.k8s.client_from_config', MagicMock(return_value=mock)):
+        with patch('intel.clusterinit.wait_for_pod_phase',
+                   MagicMock(return_value=True)):
+            clusterinit.cluster_init("fakenode1", False,
+                                     "init, discover, install",
+                                     "kcm", "Never", "/etc/kcm", "/opt/bin",
+                                     "4", "2", "")
+            called_methods = mock.method_calls
+            params = called_methods[0][1]
+            pod_spec = params[1]
+            assert "imagePullSecrets" not in pod_spec["spec"]
 
 
 def test_clusterinit_update_pod_with_init_container():


### PR DESCRIPTION
This PR resolves issue with using private Docker registry with authentication. It's passing secret name to pod definition for `describe`, `init` and `install`.

For testing purposes I've prepared private Docker registry with authorization and I've added secrets to kubernetes.

To test workflow I've used following pod:

```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    app: kcm-cluster-init-pod
  annotations:
    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"kcm", "value":"true"}]'
  name: kcm-cluster-init-pod
spec:
  containers:
  - args:
      - "/kcm/kcm.py cluster-init --all-hosts --kcm-img=registry.dev.e2e:80/kcm:latest --pull-secret=supersecret"
    command:
    - "/bin/bash"
    - "-c"
    image: registry.dev.e2e:80/kcm:latest
    name: kcm-cluster-init-pod
    volumeMounts:
    - mountPath: "/tmp/kcm"
      name: kcm-conf-dir
  restartPolicy: Never
  imagePullSecrets:
  - name: supersecret
  volumes:
  - hostPath:
      path: "/tmp/kcm"
    name: kcm-conf-dir
```