### PR TITLE
Fix pod manifest overwrite

### DIFF
--- a/intel/clusterinit.py
+++ b/intel/clusterinit.py
@@ -155,13 +155,13 @@ def run_cmd_pods(cmd_list, cmd_init_list, cmk_img, cmk_img_pol, conf_dir,
     for node_name in cmk_node_list:
         if cmd_list:
             update_pod_with_node_details(pod, node_name, cmd_list)
-            pod = k8s.ds_from(pod=pod)
+            daemon_set = k8s.ds_from(pod=pod)
         elif cmd_init_list:
             update_pod_with_node_details(pod, node_name, cmd_init_list)
 
         try:
             if cmd_list:
-                cr_pod_resp = k8s.create_ds(None, pod)
+                cr_pod_resp = k8s.create_ds(None, daemon_set)
                 logging.debug("Response while creating ds for {} command(s): "
                               "{}".format(cmd_list, cr_pod_resp))
             elif cmd_init_list:


### PR DESCRIPTION
`pod` variable had been overwritten which resulted in invalid manifest.
Tested locally.