### PR TITLE
Fix kubelet version handling

### DIFF
--- a/intel/clusterinit.py
+++ b/intel/clusterinit.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import sys
+from pkg_resources import parse_version
 
 from kubernetes.client.rest import ApiException as K8sApiException
 
@@ -121,8 +122,8 @@ def run_cmd_pods(cmd_list, cmd_init_list, cmk_img, cmk_img_pol, conf_dir,
         update_pod_with_pull_secret(pod, pull_secret)
     if cmd_list:
         update_pod(pod, "Always", conf_dir, install_dir, serviceaccount)
-        version = k8s.get_kubelet_version(None)
-        if version >= "v1.7.0":
+        version = parse_version(k8s.get_kubelet_version(None))
+        if version >= parse_version("v1.7.0"):
             pod["spec"]["tolerations"] = [{
                 "operator": "Exists"}]
         for cmd in cmd_list:
@@ -273,9 +274,9 @@ def update_pod_with_init_container(pod, cmd, cmk_img, cmk_img_pol, args):
     container_template["env"].pop()
     pod_init_containers_list = []
 
-    version = k8s.get_kubelet_version(None)
+    version = parse_version(k8s.get_kubelet_version(None))
 
-    if version >= "v1.7.0":
+    if version >= parse_version("v1.7.0"):
         pod["spec"]["initContainers"] = [container_template]
     else:
 

--- a/intel/discover.py
+++ b/intel/discover.py
@@ -17,6 +17,8 @@ import json
 import logging
 import os
 import sys
+from pkg_resources import parse_version
+
 
 from kubernetes import config as k8sconfig, client as k8sclient
 from kubernetes.client.rest import ApiException as K8sApiException
@@ -28,12 +30,12 @@ from . import k8s
 # the appropriate CMK node labels and taints.
 def discover(conf_dir):
 
-    version = k8s.get_kubelet_version(None)
-    if version == "v1.8.0":
+    version = parse_version(k8s.get_kubelet_version(None))
+    if version == parse_version("v1.8.0"):
         logging.fatal("K8s 1.8.0 is not supported. Update K8s to "
                       "version >=1.8.1 or rollback to previous versions")
 
-    if version >= "v1.8.1":
+    if version >= parse_version("v1.8.1"):
         # Patch the node with the appropriate CMK ER.
         logging.debug("Patching the node with the appropriate CMK ER.")
         add_node_er(conf_dir)
@@ -128,11 +130,11 @@ def add_node_taint():
         logging.error("Aborting discover ...")
         sys.exit(1)
 
-    version = k8s.get_kubelet_version(None)
+    version = parse_version(k8s.get_kubelet_version(None))
     node_taints_list = []
     node_taints = []
 
-    if version >= "v1.7.0":
+    if version >= parse_version("v1.7.0"):
         node_taints = node_resp["spec"]["taints"]
         if node_taints:
             node_taints_list = node_taints
@@ -154,7 +156,7 @@ def add_node_taint():
         "effect": "NoSchedule"
     })
 
-    if version >= "v1.7.0":
+    if version >= parse_version("v1.7.0"):
         value = node_taints_list
     else:
         value = json.dumps(node_taints_list)

--- a/intel/nodereport.py
+++ b/intel/nodereport.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import time
+from pkg_resources import parse_version
 
 from kubernetes import config as k8sconfig, client as k8sclient
 from . import config, custom_resource, k8s, proc, third_party, topology
@@ -39,9 +40,9 @@ def nodereport(conf_dir, seconds, publish):
             k8sconfig.load_incluster_config()
             v1beta = k8sclient.ExtensionsV1beta1Api()
 
-            version = k8s.get_kubelet_version(None)
+            version = parse_version(k8s.get_kubelet_version(None))
 
-            if version >= "v1.7.0":
+            if version >= parse_version("v1.7.0"):
                 node_report_type = \
                     custom_resource.CustomResourceDefinitionType(
                         v1beta,

--- a/intel/reconcile.py
+++ b/intel/reconcile.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import time
+from pkg_resources import parse_version
 
 from kubernetes import config as k8sconfig, client as k8sclient
 from . import config, proc, third_party, custom_resource, k8s
@@ -44,9 +45,9 @@ def reconcile(conf_dir, seconds, publish):
             k8sconfig.load_incluster_config()
             v1beta = k8sclient.ExtensionsV1beta1Api()
 
-            version = k8s.get_kubelet_version(None)
+            version = parse_version(k8s.get_kubelet_version(None))
 
-            if version >= "v1.7.0":
+            if version >= parse_version("v1.7.0"):
                 reconcile_report_type = \
                     custom_resource.CustomResourceDefinitionType(
                         v1beta,

--- a/intel/uninstall.py
+++ b/intel/uninstall.py
@@ -18,6 +18,7 @@ import logging
 import os
 import shutil
 import sys
+from pkg_resources import parse_version
 
 from time import sleep
 from kubernetes.client.rest import ApiException as K8sApiException
@@ -65,9 +66,9 @@ def remove_binary(install_dir):
 
 
 def remove_all_report():
-    version = k8s.get_kubelet_version(None)
+    version = parse_version(k8s.get_kubelet_version(None))
 
-    if version >= "v1.7.0":
+    if version >= parse_version("v1.7.0"):
         remove_report_crd("cmk-nodereport", ["cmk-nr"])
         remove_report_crd("cmk-reconcilereport", ["cmk-rr"])
 
@@ -256,10 +257,10 @@ def remove_node_taint():
                       "\"{}\" obj: {}".format(node_name, err))
         sys.exit(1)
 
-    version = k8s.get_kubelet_version(None)
+    version = parse_version(k8s.get_kubelet_version(None))
     node_taints_list = []
 
-    if version >= "v1.7.0":
+    if version >= parse_version("v1.7.0"):
         node_taints = node_resp["spec"]["taints"]
         if node_taints:
             node_taints_list = node_taints
@@ -274,7 +275,7 @@ def remove_node_taint():
     node_taints_list = \
         [taint for taint in node_taints_list if taint["key"] != "cmk"]
 
-    if version >= "v1.7.0":
+    if version >= parse_version("v1.7.0"):
         value = node_taints_list
     else:
         value = json.dumps(node_taints_list)

--- a/intel/uninstall.py
+++ b/intel/uninstall.py
@@ -297,10 +297,10 @@ def remove_node_taint():
 
 
 def remove_resource_tracking():
-    version = k8s.get_kubelet_version(None)
-    if version == "v1.8.0":
+    version = parse_version(k8s.get_kubelet_version(None))
+    if version == parse_version("v1.8.0"):
         logging.warning("Unsupported Kubernetes version")
-    elif version >= "v1.8.1":
+    elif version >= parse_version("v1.8.1"):
         remove_node_cmk_er()
     else:
         remove_node_cmk_oir()


### PR DESCRIPTION
Version string comparison gives wrong results for kubelet version >= 1.10
Use parse_version to get comparable versions.

Signed-off-by: Timo Lindqvist <timo.lindqvist@nokia.com>