### PR TITLE
Don't create resources on unsupported K8s version

### DIFF
--- a/intel/discover.py
+++ b/intel/discover.py
@@ -32,6 +32,7 @@ def discover(conf_dir):
     if version == "v1.8.0":
         logging.fatal("K8s 1.8.0 is not supported. Update K8s to "
                       "version >=1.8.1 or rollback to previous versions")
+        sys.exit(1)
 
     if version >= "v1.8.1":
         # Patch the node with the appropriate CMK ER.


### PR DESCRIPTION
* When running on unsupported Kubernetes version, "discover" should log fatal
error and exit instead of trying to create OIR and add label and taint to the
Kubernetes node

Signed-off-by: Przemyslaw Lal <przemyslawx.lal@intel.com>