### PR TITLE
Add supported pluggy versions to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ kubernetes==3.0.0
 requests>=2.12, <3.0
 pytest<=3.3.2
 pytest-cov>=2.4.0
+pluggy>=0.5, <0.7


### PR DESCRIPTION
Because we don't have the highest supported pluggy and pytest-cov versions configured in requirements.txt,
pip installs the newest pluggy 0.7.1 which is incompatible with the pytest version we use.

For the reference see issues:
https://github.com/pytest-dev/pluggy/pull/160
https://github.com/pytest-dev/pytest/issues/3727

Solution is to add pluggy's version restrictions to our requirements.

Signed-off-by: Przemyslaw Lal <przemyslawx.lal@intel.com>