### PR TITLE
Fix version parsing

### DIFF
--- a/intel/clusterinit.py
+++ b/intel/clusterinit.py
@@ -16,7 +16,6 @@ import json
 import logging
 import sys
 import yaml
-from pkg_resources import parse_version
 
 from kubernetes import client as k8sclient
 from kubernetes.client.rest import ApiException as K8sApiException
@@ -79,8 +78,8 @@ def cluster_init(host_list, all_hosts, cmd_list, cmk_img, cmk_img_pol,
                  exclusive_mode, namespace)
 
     # Run mutating webhook admission controller on supported cluster
-    version = parse_version(k8s.get_kubelet_version(None))
-    if version >= parse_version("v1.9.0"):
+    version = util.parse_version(k8s.get_kubelet_version(None))
+    if version >= util.parse_version("v1.9.0"):
         deploy_webhook(namespace, conf_dir, install_dir, serviceaccount,
                        cmk_img)
 
@@ -138,8 +137,8 @@ def run_cmd_pods(cmd_list, cmd_init_list, cmk_img, cmk_img_pol, conf_dir,
         update_pod_with_pull_secret(pod, pull_secret)
     if cmd_list:
         update_pod(pod, "Always", conf_dir, install_dir, serviceaccount)
-        version = parse_version(k8s.get_kubelet_version(None))
-        if version >= parse_version("v1.7.0"):
+        version = util.parse_version(k8s.get_kubelet_version(None))
+        if version >= util.parse_version("v1.7.0"):
             pod["spec"]["tolerations"] = [{
                 "operator": "Exists"}]
         for cmd in cmd_list:
@@ -373,9 +372,9 @@ def update_pod_with_init_container(pod, cmd, cmk_img, cmk_img_pol, args):
     container_template["env"].pop()
     pod_init_containers_list = []
 
-    version = parse_version(k8s.get_kubelet_version(None))
+    version = util.parse_version(k8s.get_kubelet_version(None))
 
-    if version >= parse_version("v1.7.0"):
+    if version >= util.parse_version("v1.7.0"):
         pod["spec"]["initContainers"] = [container_template]
     else:
 

--- a/intel/discover.py
+++ b/intel/discover.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from intel import config
+from intel import config, util
 import json
 import logging
 import os
 import sys
-from pkg_resources import parse_version
 
 
 from kubernetes import config as k8sconfig, client as k8sclient
@@ -30,13 +29,13 @@ from . import k8s
 # the appropriate CMK node labels and taints.
 def discover(conf_dir):
 
-    version = parse_version(k8s.get_kubelet_version(None))
-    if version == parse_version("v1.8.0"):
+    version = util.parse_version(k8s.get_kubelet_version(None))
+    if version == util.parse_version("v1.8.0"):
         logging.fatal("K8s 1.8.0 is not supported. Update K8s to "
                       "version >=1.8.1 or rollback to previous versions")
         sys.exit(1)
 
-    if version >= parse_version("v1.8.1"):
+    if version >= util.parse_version("v1.8.1"):
         # Patch the node with the appropriate CMK ER.
         logging.debug("Patching the node with the appropriate CMK ER.")
         add_node_er(conf_dir)
@@ -131,11 +130,11 @@ def add_node_taint():
         logging.error("Aborting discover ...")
         sys.exit(1)
 
-    version = parse_version(k8s.get_kubelet_version(None))
+    version = util.parse_version(k8s.get_kubelet_version(None))
     node_taints_list = []
     node_taints = []
 
-    if version >= parse_version("v1.7.0"):
+    if version >= util.parse_version("v1.7.0"):
         node_taints = node_resp["spec"]["taints"]
         if node_taints:
             node_taints_list = node_taints
@@ -157,7 +156,7 @@ def add_node_taint():
         "effect": "NoSchedule"
     })
 
-    if version >= parse_version("v1.7.0"):
+    if version >= util.parse_version("v1.7.0"):
         value = node_taints_list
     else:
         value = json.dumps(node_taints_list)

--- a/intel/nodereport.py
+++ b/intel/nodereport.py
@@ -17,10 +17,9 @@ import json
 import logging
 import os
 import time
-from pkg_resources import parse_version
 
 from kubernetes import config as k8sconfig, client as k8sclient
-from . import config, custom_resource, k8s, proc, third_party, topology
+from . import config, custom_resource, k8s, proc, third_party, topology, util
 
 
 def nodereport(conf_dir, seconds, publish):
@@ -40,9 +39,9 @@ def nodereport(conf_dir, seconds, publish):
             k8sconfig.load_incluster_config()
             v1beta = k8sclient.ExtensionsV1beta1Api()
 
-            version = parse_version(k8s.get_kubelet_version(None))
+            version = util.parse_version(k8s.get_kubelet_version(None))
 
-            if version >= parse_version("v1.7.0"):
+            if version >= util.parse_version("v1.7.0"):
                 node_report_type = \
                     custom_resource.CustomResourceDefinitionType(
                         v1beta,

--- a/intel/reconcile.py
+++ b/intel/reconcile.py
@@ -16,10 +16,9 @@ import json
 import logging
 import os
 import time
-from pkg_resources import parse_version
 
 from kubernetes import config as k8sconfig, client as k8sclient
-from . import config, proc, third_party, custom_resource, k8s
+from . import config, proc, third_party, custom_resource, k8s, util
 
 
 def reconcile(conf_dir, seconds, publish):
@@ -45,9 +44,9 @@ def reconcile(conf_dir, seconds, publish):
             k8sconfig.load_incluster_config()
             v1beta = k8sclient.ExtensionsV1beta1Api()
 
-            version = parse_version(k8s.get_kubelet_version(None))
+            version = util.parse_version(k8s.get_kubelet_version(None))
 
-            if version >= parse_version("v1.7.0"):
+            if version >= util.parse_version("v1.7.0"):
                 reconcile_report_type = \
                     custom_resource.CustomResourceDefinitionType(
                         v1beta,

--- a/intel/uninstall.py
+++ b/intel/uninstall.py
@@ -18,7 +18,6 @@ import logging
 import os
 import shutil
 import sys
-from pkg_resources import parse_version
 
 from time import sleep
 from kubernetes.client.rest import ApiException as K8sApiException
@@ -27,6 +26,7 @@ from . import config, third_party
 from . import reconcile
 from . import discover
 from . import k8s
+from . import util
 
 
 def uninstall(install_dir, conf_dir, namespace):
@@ -68,9 +68,9 @@ def remove_binary(install_dir):
 
 
 def remove_all_report():
-    version = parse_version(k8s.get_kubelet_version(None))
+    version = util.parse_version(k8s.get_kubelet_version(None))
 
-    if version >= parse_version("v1.7.0"):
+    if version >= util.parse_version("v1.7.0"):
         remove_report_crd("cmk-nodereport", ["cmk-nr"])
         remove_report_crd("cmk-reconcilereport", ["cmk-rr"])
 
@@ -259,10 +259,10 @@ def remove_node_taint():
                       "\"{}\" obj: {}".format(node_name, err))
         sys.exit(1)
 
-    version = parse_version(k8s.get_kubelet_version(None))
+    version = util.parse_version(k8s.get_kubelet_version(None))
     node_taints_list = []
 
-    if version >= parse_version("v1.7.0"):
+    if version >= util.parse_version("v1.7.0"):
         node_taints = node_resp["spec"]["taints"]
         if node_taints:
             node_taints_list = node_taints
@@ -277,7 +277,7 @@ def remove_node_taint():
     node_taints_list = \
         [taint for taint in node_taints_list if taint["key"] != "cmk"]
 
-    if version >= parse_version("v1.7.0"):
+    if version >= util.parse_version("v1.7.0"):
         value = node_taints_list
     else:
         value = json.dumps(node_taints_list)
@@ -299,10 +299,10 @@ def remove_node_taint():
 
 
 def remove_resource_tracking():
-    version = parse_version(k8s.get_kubelet_version(None))
-    if version == parse_version("v1.8.0"):
+    version = util.parse_version(k8s.get_kubelet_version(None))
+    if version == util.parse_version("v1.8.0"):
         logging.warning("Unsupported Kubernetes version")
-    elif version >= parse_version("v1.8.1"):
+    elif version >= util.parse_version("v1.8.1"):
         remove_node_cmk_er()
     else:
         remove_node_cmk_oir()
@@ -354,8 +354,8 @@ def remove_node_cmk_er():
 
 
 def remove_webhook_resources(prefix, namespace):
-    version = parse_version(k8s.get_kubelet_version(None))
-    if version >= parse_version("v1.9.0"):
+    version = util.parse_version(k8s.get_kubelet_version(None))
+    if version >= util.parse_version("v1.9.0"):
         try:
             k8s.delete_mutating_webhook_configuration(
                                             None, "{}-config".format(prefix))

--- a/intel/util.py
+++ b/intel/util.py
@@ -21,6 +21,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from packaging.version import parse
 
 from os.path import normpath, realpath, join, pardir
 
@@ -39,6 +40,19 @@ def ldh_convert_check(name):
                       "[a-z0-9]([-a-z0-9]*[a-z0-9])?".format(name_con))
         exit(1)
     return name_con
+
+
+# Utility function to parse K8s version strings into basic semver format.
+# NOTE: Based on regexp used in Kubernetes source code here:
+# https://github.com/kubernetes/kubernetes/blob/v1.11.3/pkg/util/version/version.go#L37
+# NOTE: Extra parts such as pre-release and build metadata are ignored.
+def parse_version(version_str):
+    version_regex = r"^\s*v?([0-9]+(?:\.[0-9]+)*).*"
+    matches = re.search(version_regex, version_str, re.UNICODE)
+    if matches:
+        return parse(matches.group(1))
+    else:
+        raise ValueError("Could not parse %s as version string" % version_str)
 
 
 def generate_key(size):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest-cov>=2.4.0
 cryptography>=2.3
 yamlreader==3.0.4
 pluggy>=0.5, <0.7
+packaging==17.1

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -67,3 +67,28 @@ def test_ldh_parser_fail():
     for name in original_invalid_node_names:
         with pytest.raises(SystemExit):
             util.ldh_convert_check(name)
+
+
+def test_parse_version_success():
+    assert util.parse_version("1") == util.parse_version("1.0.0")
+    assert util.parse_version("v2") > util.parse_version("v1.0.0")
+    assert util.parse_version("v10.0.0") > util.parse_version("v2.0.0")
+    assert util.parse_version("v1.10.0") > util.parse_version("v1.9.0")
+    assert util.parse_version("v1.10.11") > util.parse_version("v1.9.2")
+    assert util.parse_version("v1.18.11") == util.parse_version("v1.18.11")
+    assert util.parse_version("v1.9.11-dirty") > util.parse_version("v1.5.2")
+    assert util.parse_version("v1.1-dirty") > util.parse_version("v1")
+    assert util.parse_version("v1.10.0-rc.1") > util.parse_version("v1.9")
+    assert (util.parse_version("v1.12.0") ==
+            util.parse_version("v1.12.0-alpha.0.2126+c9e1abca8c6d24-dirty"))
+
+
+def test_parse_version_fail():
+    with pytest.raises(ValueError):
+        util.parse_version("invalid_version")
+
+    with pytest.raises(ValueError):
+        util.parse_version("a1.2.3")
+
+    with pytest.raises(ValueError):
+        util.parse_version("v-1.6.0")


### PR DESCRIPTION
Fix issue where K8s version strings containing extra parts
such as prerelease string and build metadata were incorrectly
recognized as always older, due to the way pkg_resources.parse_version()
handles them.

This commit adds utility function to parse version strings
ignoring those extra parts.

Signed-off-by: Przemyslaw Lal <przemyslawx.lal@intel.com>