### PR TITLE
use natural sorting for advertised CPUs

### DIFF
--- a/intel/isolate.py
+++ b/intel/isolate.py
@@ -82,7 +82,7 @@ def isolate(conf_dir, pool_name, no_affinity, command, args, socket_id=None):
     # NOTE: we spawn the child process after exiting the config lock context.
     try:
         # Advertise assigned CPU IDs in the environment.
-        clists.sort(key=lambda cl: cl.cpus())
+        clists.sort(key=lambda cl: int(cl.cpus().split(",")[0]))
         cpu_ids = ','.join([cl.cpus() for cl in clists])
         os.environ[ENV_CPUS_ASSIGNED] = cpu_ids
 


### PR DESCRIPTION
This commit fixes issue where assigned CPUs are sorted
in alphabetical order, i.e.:
["1", "100", "20", "3", ...]
instead of more intuitive natural order:
["1", "3", "20", "100", ...]
introduced in this change.

Signed-off-by: Przemyslaw Lal <przemyslawx.lal@intel.com>