### PR TITLE
fix git remote HTTPS URL handling in make_release script

### DIFF
--- a/.release/make_release.py
+++ b/.release/make_release.py
@@ -50,9 +50,9 @@ def validate_commit_msg_get_tag():
 
 
 def get_org_and_repo_name():
-    origin_url = githelpers.execute_git_cmd("config --get remote.origin.url").strip(".git").split(":")
-    repo_info = origin_url[-1].split("/")
-    return repo_info[0], repo_info[1]
+    origin_url = githelpers.execute_git_cmd("config --get remote.origin.url").rstrip(".git")
+    repo_info = re.split(':|\/', origin_url)
+    return repo_info[-2], repo_info[-1]
 
 
 def main():


### PR DESCRIPTION
This change fixes an issue with the make_release script.
makre_release.py assumed that git remote is set to URL in SSH format.
This caused an issue when the repo was cloned using HTTPS URL.
This commit makes the relase script work for both HTTPS and SSH remote URLs.

Signed-off-by: Przemyslaw Lal <przemyslawx.lal@intel.com>