### PR TITLE
Updating CMK to allow request of 0 cores to exclusive/shared core pools.

### DIFF
--- a/intel/discover.py
+++ b/intel/discover.py
@@ -58,8 +58,6 @@ def add_node_oir(conf_dir):
     with c.lock():
         if "exclusive" not in c.pools():
             raise KeyError("Exclusive pool does not exist")
-        if len(c.pool("exclusive").cpu_lists()) == 0:
-            raise KeyError("No CPU list in exclusive pool")
         num_slots = len(c.pool("exclusive").cpu_lists())
 
     patch_path = ("/status/capacity/pod.alpha.kubernetes.io~1opaque-int-"
@@ -85,8 +83,6 @@ def add_node_er(conf_dir):
     with c.lock():
         if "exclusive" not in c.pools():
             raise KeyError("Exclusive pool does not exist")
-        if len(c.pool("exclusive").cpu_lists()) == 0:
-            raise KeyError("No CPU list in exclusive pool")
         num_slots = len(c.pool("exclusive").cpu_lists())
 
     patch_path = ("/status/capacity/cmk.intel.com~1exclusive-cores")

--- a/intel/init.py
+++ b/intel/init.py
@@ -159,7 +159,7 @@ def assign(cores, pool, count=None):
                            (count, pool, len(free_cores)))
 
     assigned = free_cores
-    if count:
+    if count is not None:
         assigned = free_cores[:count]
 
     for c in assigned:

--- a/tests/unit/test_discover.py
+++ b/tests/unit/test_discover.py
@@ -43,29 +43,6 @@ def test_discover_no_exclusive():
     assert err.value.args[0] == expected_msg
 
 
-def test_discover_no_cl_exclusive():
-    temp_dir = tempfile.mkdtemp()
-    conf_dir = os.path.join(temp_dir, "discover")
-
-    helpers.execute(
-        "cp",
-        ["-r",
-         helpers.conf_dir("ok"),
-         "{}".format(conf_dir)]
-    )
-    helpers.execute(
-        "rm",
-        ["-r",
-         "{}".format(os.path.join(conf_dir, "pools",
-                                  "exclusive", "*"))]
-    )
-
-    with pytest.raises(KeyError) as err:
-        discover.add_node_oir(conf_dir)
-    expected_msg = "No CPU list in exclusive pool"
-    assert err.value.args[0] == expected_msg
-
-
 class FakeHTTPResponse:
     def __init__(self, status=None, reason=None, data=None):
         self.status = status
@@ -238,24 +215,4 @@ def test_discover_add_node_er_no_exclusive_pool_failure():
     )
 
     with pytest.raises(KeyError, message="Exclusive pool does not exist"):
-        discover.add_node_er(conf_dir)
-
-
-def test_discover_add_node_er_no_exclusive_cores_failure():
-    temp_dir = tempfile.mkdtemp()
-    conf_dir = os.path.join(temp_dir, "discover")
-
-    helpers.execute(
-        "cp",
-        ["-r",
-         helpers.conf_dir("ok"),
-         "{}".format(conf_dir)]
-    )
-    helpers.execute(
-        "rm",
-        ["-r",
-         "{}".format(os.path.join(conf_dir, "pools", "exclusive", "0"))]
-    )
-
-    with pytest.raises(KeyError, message="No CPU list in exclusive pool"):
         discover.add_node_er(conf_dir)


### PR DESCRIPTION
Removing error raised in discover.py when no cores exist in exclusive core pool.

This should not be an error and discover.py should still patch the node with
  exclusive-cores resource set to '0'.
Removed unit tests associated with the above error as no longer needed.