### PR TITLE
Added release automation for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,18 @@
+language: python
 sudo: required
-
+python:
+  - "3.4"
 services:
-    - docker
-
-script:
-    - docker build -t cmk .
+  - docker
+jobs:
+  include:
+    - stage: "Build and test"
+      script: make docker
+    - stage: "Release"
+      before_script:
+        # Set up git user name and update remote origin
+        - git config --local user.name "intel-bot"
+        - git config --local user.email "intel_bot@intel.com"
+        - git remote set-url origin https://${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG}
+      script: make release
+      if: branch = master

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: docker docs
+.PHONY: docker docs release
 
 all: docker
 
@@ -54,3 +54,7 @@ docs:
 	sed -i"" "s/\.md/\.html/g" docs/html/docs/operator.html
 	sed -i"" "s/\.md/\.html/g" docs/html/docs/user.html
 	sed -i"" "s/\.md/\.html/g" docs/html/docs/architecture.html
+
+# Trigger for github release used by travis.yml
+release:
+	.release/make_release.py

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,15 +19,15 @@ General flow is:
  - run `prepare_release.py` script
  - create PR, get review
  - "Rebase and merge" PR into master branch
+ - Travis will build, test and make release automatically
  - If the repository has [Jenkins CI/CD](#jenkins-release-job) job
    - Jenkins CI/CD will build VM based on `.release/Vagrantfile`
    - Jenkins CI/CD will run `.release/make_release.py`
- - If there is no Jenkins CI/CD or you want to release in [manual](#manual-release) way:
+ - If you want to release in [manual](#manual-release) way:
    - spawn release VM (`vagrant up`in `.release` directory)
    - run `make_release.py` script in the VM
    
 In any case, please read [below](#prepare-release-script) paragraph for more information.
-If you want to release manually, please read also
 
 
 
@@ -74,6 +74,8 @@ Additionally, tag and release are created once PR from release branch gets onto 
 
 ## Make release
 ---
+#### Travis
+By default travis will build, test and make the release automatically. To set this up, add secret environment variable GITHUB_TOKEN in travis repository settings and update corresponding git username and email.
 
 #### Jenkins release job
 If Jenkins CI/CD is present and configured with the "release job" - no user intervention is needed.


### PR DESCRIPTION
* Added release automation for travis

This change adds travis configuration for automatic releases.
Makefile has been adjusted for build, test and release flows.
Travis configuration requires GITHUB_TOKEN secret variable.