### PR TITLE
Add build process improvements and fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,5 @@
 .cache/*
 .tox/*
 cmk.egg-info/*
-*.pyc
-*/__pycache__/*
+**/*.pyc
+**/__pycache__/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 jobs:
   include:
     - stage: "Build and test"
-      script: make docker
+      script: make test
     - stage: "Release"
       before_script:
         # Set up git user name and update remote origin

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,6 @@ WORKDIR /cmk
 
 RUN chmod +x /cmk/cmk.py
 
-RUN tox -e lint
-RUN tox -e unit
-RUN tox -e integration
-RUN tox -e coverage
-
 RUN /cmk/cmk.py --help && echo ""
 
-ENTRYPOINT [ "/cmk/cmk.py" ]
+CMD [ "/cmk/cmk.py" ]

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: docker docs release
+.PHONY: docker docs release test
 
 all: docker
 
@@ -23,10 +23,14 @@ version=v1.3.0
 jenkins: docker
 
 docker:
-	docker build --no-cache -t cmk:$(version) .
+	docker build -t cmk:$(version) .
 	@echo ""
 	@echo "To run the docker image, run command:"
 	@echo "docker run -it cmk:$(version) ..."
+
+test: docker
+	docker run --rm cmk:$(version) tox -e lint,unit,integration,coverage
+
 
 # Output neatly formatted HTML docs to `docs/html`.
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ pyinstaller>=3.2, <4.0
 kubernetes==8.0.0
 requests>=2.12, <3.0
 pytest<=3.3.2
-pytest-cov>=2.4.0
-cryptography>=2.3
+pytest-cov>=2.4.0, <2.6.1
+cryptography>=2.3, <=2.4.2
 yamlreader==3.0.4
 pluggy>=0.5, <0.7
 packaging==17.1


### PR DESCRIPTION
* add maximum supported versions for pytest-cov and cryptography packages to ensure no build breakages in the future.
* remove tests execution from regular image build
* add new Makefile target for tests, to execute run `make test`
* update Travis job configuration to reflect this change