### PR TITLE
upgrade requests and urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ docopt>=0.6, <1.0
 psutil>=5.0, <5.5
 pyinstaller>=3.2, <4.0
 kubernetes==8.0.0
-requests>=2.12, <3.0
+requests>=2.21, <3.0
+urllib3==1.24.2
 pytest<=3.3.2
 pytest-cov>=2.4.0, <2.6.1
 cryptography>=2.3, <=2.4.2


### PR DESCRIPTION
This fixes warning messages coming from the `requests` library, breaking integration tests.