### PR TITLE
Add ENV_CPUS_ASSIGNED_MASK env variable

### DIFF
--- a/intel/isolate.py
+++ b/intel/isolate.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from . import config, proc
+from intel import util
 import logging
 import os
 import random
@@ -21,6 +22,7 @@ import signal
 import subprocess
 
 ENV_CPUS_ASSIGNED = "CMK_CPUS_ASSIGNED"
+ENV_CPUS_ASSIGNED_MASK = "CMK_CPUS_ASSIGNED_MASK"
 ENV_CPUS_INFRA = "CMK_CPUS_INFRA"
 ENV_NUM_CORES = "CMK_NUM_CORES"
 
@@ -84,6 +86,9 @@ def isolate(conf_dir, pool_name, no_affinity, command, args, socket_id=None):
         clists.sort(key=lambda cl: int(cl.cpus().split(",")[0]))
         cpu_ids = ','.join([cl.cpus() for cl in clists])
         os.environ[ENV_CPUS_ASSIGNED] = cpu_ids
+        cpus_arr = [int(n) for n in cpu_ids.split(',')]
+        cpus_bit_mask = util.convert_array2bitmask(cpus_arr)
+        os.environ[ENV_CPUS_ASSIGNED_MASK] = cpus_bit_mask
 
         # Advertise infra pool CPU IDs
         infra_pool = pools.get("infra")

--- a/intel/util.py
+++ b/intel/util.py
@@ -105,3 +105,10 @@ def generate_secrets(service, namespace):
     )
 
     return b64encode(cert_pem).decode(), b64encode(private_key_pem).decode()
+
+
+def convert_array2bitmask(array):
+    bitmask = 0
+    for val in array:
+        bitmask = bitmask | (1 << val)
+    return str(hex(bitmask))[2:].upper()

--- a/tests/integration/test_cmk_isolate.py
+++ b/tests/integration/test_cmk_isolate.py
@@ -34,6 +34,7 @@ def test_cmk_isolate_child_env():
 
     assert helpers.execute(integration.cmk(), args, proc_env) == b"""\
 CMK_CPUS_ASSIGNED=0
+CMK_CPUS_ASSIGNED_MASK=1
 CMK_PROC_FS=/proc
 """
 
@@ -46,6 +47,7 @@ def test_cmk_isolate_child_env_infra():
 
     assert helpers.execute(integration.cmk(), args, proc_env) == b"""\
 CMK_CPUS_ASSIGNED=1
+CMK_CPUS_ASSIGNED_MASK=2
 CMK_CPUS_INFRA=0
 CMK_PROC_FS=/proc
 """
@@ -197,6 +199,7 @@ def test_cmk_isolate_multiple_cores_exclusive():
 
     assert helpers.execute(integration.cmk(), args, env) == b"""\
 CMK_CPUS_ASSIGNED=0,1
+CMK_CPUS_ASSIGNED_MASK=3
 CMK_PROC_FS=/proc
 CMK_NUM_CORES=2
 """
@@ -211,6 +214,7 @@ def test_cmk_isolate_multiple_cores_shared():
 
     assert helpers.execute(integration.cmk(), args, env) == b"""\
 CMK_CPUS_ASSIGNED=0
+CMK_CPUS_ASSIGNED_MASK=1
 CMK_PROC_FS=/proc
 CMK_NUM_CORES=2
 """


### PR DESCRIPTION
Some applications expect a mask of cpus on which they isolate themselves
(pktgen, testpmd). For the convenience of running such applications in cmk
containers, it is useful to add allocated CPUs to the ENV, not only in the
list, but also in the form of a mask.

Signed-off-by: Liliia Butorina <l.butorina@partner.samsung.com>