### PR TITLE
don't execute release job on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ jobs:
         - git config --local user.email "intel_bot@intel.com"
         - git remote set-url origin https://${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG}
       script: make release
-      if: branch = master
+      if: branch = master AND type = push AND fork = false


### PR DESCRIPTION
This patch adds extra filters to Travis job, so that there's no "Release job" executed on PRs from the external contributors which always fails due to missing GitHub token on forks.