### PR TITLE
Update to use namespace for operator (avoid using default)

### DIFF
--- a/intel/k8s.py
+++ b/intel/k8s.py
@@ -28,11 +28,7 @@ def get_pod_template(saname="cmk-serviceaccount"):
             }
         },
         "spec": {
-<<<<<<< HEAD
             "serviceAccount": saname,
-=======
-            "serviceAccount":saname,
->>>>>>> 8e5a2a0f9150531063aa44cd1e15302b4b1ade0d
             "nodeName": "NODENAME",
             "containers": [
             ],

--- a/intel/k8s.py
+++ b/intel/k8s.py
@@ -18,7 +18,7 @@ from kubernetes import client as k8sclient, config as k8sconfig
 from kubernetes.client import V1Namespace, V1DeleteOptions
 
 
-def get_pod_template():
+def get_pod_template(saname="cmk-serviceaccount"):
     pod_template = {
         "apiVersion": "v1",
         "kind": "Pod",
@@ -28,6 +28,7 @@ def get_pod_template():
             }
         },
         "spec": {
+            "serviceAccount": saname,
             "nodeName": "NODENAME",
             "containers": [
             ],

--- a/intel/k8s.py
+++ b/intel/k8s.py
@@ -28,7 +28,11 @@ def get_pod_template(saname="cmk-serviceaccount"):
             }
         },
         "spec": {
+<<<<<<< HEAD
             "serviceAccount": saname,
+=======
+            "serviceAccount":saname,
+>>>>>>> 8e5a2a0f9150531063aa44cd1e15302b4b1ade0d
             "nodeName": "NODENAME",
             "containers": [
             ],

--- a/resources/authorization/cmk-namespace.yaml
+++ b/resources/authorization/cmk-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cmk-namespace

--- a/resources/authorization/cmk-rbac-rules.yaml
+++ b/resources/authorization/cmk-rbac-rules.yaml
@@ -60,7 +60,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount
-  namespace: intel-cmk
+  namespace: cmk-namespace
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -73,7 +73,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount
-  namespace: intel-cmk
+  namespace: cmk-namespace
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -86,7 +86,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount
-  namespace: intel-cmk
+  namespace: cmk-namespace
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -99,7 +99,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount
-  namespace: intel-cmk
+  namespace: cmk-namespace
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -112,7 +112,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount
-  namespace: intel-cmk
+  namespace: cmk-namespace
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -125,4 +125,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount
-  namespace: intel-cmk
+  namespace: cmk-namespace

--- a/resources/authorization/cmk-rbac-rules.yaml
+++ b/resources/authorization/cmk-rbac-rules.yaml
@@ -60,7 +60,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount
-  namespace: default
+  namespace: intel-cmk
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -73,7 +73,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount
-  namespace: default
+  namespace: intel-cmk
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -86,7 +86,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount
-  namespace: default
+  namespace: intel-cmk
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -99,7 +99,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount
-  namespace: default
+  namespace: intel-cmk
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -112,7 +112,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount
-  namespace: default
+  namespace: intel-cmk
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -125,4 +125,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount
-  namespace: default
+  namespace: intel-cmk

--- a/resources/authorization/cmk-serviceaccount.yaml
+++ b/resources/authorization/cmk-serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cmk-serviceaccount
-  #namespace: user-supplied-namespace
+  namespace: intel-cmk

--- a/resources/authorization/cmk-serviceaccount.yaml
+++ b/resources/authorization/cmk-serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cmk-serviceaccount
-  namespace: intel-cmk
+  namespace: cmk-namespace

--- a/resources/pods/cmk-cluster-init-pod.yaml
+++ b/resources/pods/cmk-cluster-init-pod.yaml
@@ -18,13 +18,13 @@ metadata:
   labels:
     app: cmk-cluster-init-pod
   name: cmk-cluster-init-pod
-  #namespace: user-supplied-namespace      
+  namespace: intel-cmk
 spec:
   serviceAccountName: cmk-serviceaccount
   containers:
   - args:
       # Change this value to pass different options to cluster-init.
-      - "/cmk/cmk.py cluster-init --host-list=node1,node2,node3 --saname=cmk-serviceaccount"
+      - "/cmk/cmk.py cluster-init --host-list=node1,node2,node3 --saname=cmk-serviceaccount --namespace=intel-cmk --cmk-img=cmk:v1.3.1"
     command:
     - "/bin/bash"
     - "-c"

--- a/resources/pods/cmk-cluster-init-pod.yaml
+++ b/resources/pods/cmk-cluster-init-pod.yaml
@@ -18,13 +18,13 @@ metadata:
   labels:
     app: cmk-cluster-init-pod
   name: cmk-cluster-init-pod
-  namespace: intel-cmk
+  namespace: cmk-namespace
 spec:
   serviceAccountName: cmk-serviceaccount
   containers:
   - args:
       # Change this value to pass different options to cluster-init.
-      - "/cmk/cmk.py cluster-init --host-list=node1,node2,node3 --saname=cmk-serviceaccount --namespace=intel-cmk --cmk-img=cmk:v1.3.1"
+      - "/cmk/cmk.py cluster-init --host-list=node1,node2,node3 --saname=cmk-serviceaccount --namespace=cmk-namespace"
     command:
     - "/bin/bash"
     - "-c"

--- a/resources/pods/cmk-discover-pod.yaml
+++ b/resources/pods/cmk-discover-pod.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app: cmk-discover-pod
   name: cmk-discover-pod
-  namespace: intel-cmk
+  namespace: cmk-namespace
 spec:
   serviceAccountName: cmk-serviceaccount
   containers:

--- a/resources/pods/cmk-discover-pod.yaml
+++ b/resources/pods/cmk-discover-pod.yaml
@@ -18,6 +18,7 @@ metadata:
   labels:
     app: cmk-discover-pod
   name: cmk-discover-pod
+  namespace: intel-cmk
 spec:
   serviceAccountName: cmk-serviceaccount
   containers:

--- a/resources/pods/cmk-init-pod.yaml
+++ b/resources/pods/cmk-init-pod.yaml
@@ -18,6 +18,7 @@ metadata:
   labels:
     app: cmk-init-pod
   name: cmk-init-pod
+  namespace: intel-cmk  
 spec:
   serviceAccountName: cmk-serviceaccount
   containers:

--- a/resources/pods/cmk-init-pod.yaml
+++ b/resources/pods/cmk-init-pod.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app: cmk-init-pod
   name: cmk-init-pod
-  namespace: intel-cmk  
+  namespace: cmk-namespace  
 spec:
   serviceAccountName: cmk-serviceaccount
   containers:

--- a/resources/pods/cmk-install-pod.yaml
+++ b/resources/pods/cmk-install-pod.yaml
@@ -18,6 +18,7 @@ metadata:
   labels:
     app: cmk-install-pod
   name: cmk-install-pod
+  namespace: intel-cmk
 spec:
   serviceAccountName: cmk-serviceaccount
   containers:

--- a/resources/pods/cmk-install-pod.yaml
+++ b/resources/pods/cmk-install-pod.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app: cmk-install-pod
   name: cmk-install-pod
-  namespace: intel-cmk
+  namespace: cmk-namespace
 spec:
   serviceAccountName: cmk-serviceaccount
   containers:

--- a/resources/pods/cmk-isolate-pod-no-webhook.yaml
+++ b/resources/pods/cmk-isolate-pod-no-webhook.yaml
@@ -21,7 +21,7 @@ metadata:
   labels:
     app: cmk-isolate-pod
   name: cmk-isolate-pod
-  #namespace: user-supplied-namespace
+  namespace: intel-cmk
 spec:
   serviceAccountName: cmk-serviceaccount
   tolerations:

--- a/resources/pods/cmk-isolate-pod-no-webhook.yaml
+++ b/resources/pods/cmk-isolate-pod-no-webhook.yaml
@@ -21,7 +21,7 @@ metadata:
   labels:
     app: cmk-isolate-pod
   name: cmk-isolate-pod
-  namespace: intel-cmk
+  namespace: cmk-namespace
 spec:
   serviceAccountName: cmk-serviceaccount
   tolerations:

--- a/resources/pods/cmk-isolate-pod.yaml
+++ b/resources/pods/cmk-isolate-pod.yaml
@@ -24,7 +24,7 @@ metadata:
 # Consumed by mutating webhook
   annotations:
     cmk.intel.com/mutate: "true" # accepted values to trigger mutation: "true", "True", "1"
-    namespace: cmk-namespace
+  namespace: cmk-namespace
 spec:
   restartPolicy: Never
   containers:

--- a/resources/pods/cmk-isolate-pod.yaml
+++ b/resources/pods/cmk-isolate-pod.yaml
@@ -24,7 +24,7 @@ metadata:
 # Consumed by mutating webhook
   annotations:
     cmk.intel.com/mutate: "true" # accepted values to trigger mutation: "true", "True", "1"
-    namespace: intel-cmk
+    namespace: cmk-namespace
 spec:
   restartPolicy: Never
   containers:

--- a/resources/pods/cmk-isolate-pod.yaml
+++ b/resources/pods/cmk-isolate-pod.yaml
@@ -24,7 +24,7 @@ metadata:
 # Consumed by mutating webhook
   annotations:
     cmk.intel.com/mutate: "true" # accepted values to trigger mutation: "true", "True", "1"
-  #namespace: user-supplied-namespace
+    namespace: intel-cmk
 spec:
   restartPolicy: Never
   containers:

--- a/resources/pods/cmk-legacy-isolate-pod.yaml
+++ b/resources/pods/cmk-legacy-isolate-pod.yaml
@@ -24,7 +24,7 @@ metadata:
 #  annotations:
 #    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"cmk", "value":"true"}]'
   name: cmk-isolate-pod
-  #namespace: user-supplied-namespace
+  namespace: intel-cmk
 spec:
   serviceAccountName: cmk-serviceaccount
 # Needed for k8s >= 1.7

--- a/resources/pods/cmk-legacy-isolate-pod.yaml
+++ b/resources/pods/cmk-legacy-isolate-pod.yaml
@@ -24,7 +24,7 @@ metadata:
 #  annotations:
 #    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"cmk", "value":"true"}]'
   name: cmk-isolate-pod
-  namespace: intel-cmk
+  namespace: cmk-namespace
 spec:
   serviceAccountName: cmk-serviceaccount
 # Needed for k8s >= 1.7

--- a/resources/pods/cmk-nodereport-daemonset.yaml
+++ b/resources/pods/cmk-nodereport-daemonset.yaml
@@ -21,6 +21,7 @@ metadata:
 #  annotations:
 #    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"cmk", "value":"true"}]'
   name: cmk-node-report-ds-all
+  namespace: intel-cmk
 spec:
   template:
     metadata:

--- a/resources/pods/cmk-nodereport-daemonset.yaml
+++ b/resources/pods/cmk-nodereport-daemonset.yaml
@@ -21,7 +21,7 @@ metadata:
 #  annotations:
 #    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"cmk", "value":"true"}]'
   name: cmk-node-report-ds-all
-  namespace: intel-cmk
+  namespace: cmk-namespace
 spec:
   template:
     metadata:

--- a/resources/pods/cmk-reconcile-daemonset.yaml
+++ b/resources/pods/cmk-reconcile-daemonset.yaml
@@ -21,7 +21,7 @@ metadata:
 #  annotations:
 #    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"cmk", "value":"true"}]'
   name: cmk-reconcile-ds-all
-  namespace: intel-cmk
+  namespace: cmk-namespace
 spec:
   template:
     metadata:

--- a/resources/pods/cmk-reconcile-daemonset.yaml
+++ b/resources/pods/cmk-reconcile-daemonset.yaml
@@ -21,6 +21,7 @@ metadata:
 #  annotations:
 #    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"cmk", "value":"true"}]'
   name: cmk-reconcile-ds-all
+  namespace: intel-cmk
 spec:
   template:
     metadata:

--- a/resources/pods/cmk-uninstall-all-daemonset.yaml
+++ b/resources/pods/cmk-uninstall-all-daemonset.yaml
@@ -21,6 +21,7 @@ metadata:
 #  annotations:
 #    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"cmk", "value":"true"}]'
   name: cmk-uninstall-all-nodes
+  namespace: intel-cmk
 spec:
   template:
     metadata:

--- a/resources/pods/cmk-uninstall-all-daemonset.yaml
+++ b/resources/pods/cmk-uninstall-all-daemonset.yaml
@@ -21,7 +21,7 @@ metadata:
 #  annotations:
 #    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"cmk", "value":"true"}]'
   name: cmk-uninstall-all-nodes
-  namespace: intel-cmk
+  namespace: cmk-namespace
 spec:
   template:
     metadata:

--- a/resources/pods/cmk-uninstall-pod.yaml
+++ b/resources/pods/cmk-uninstall-pod.yaml
@@ -21,7 +21,7 @@ metadata:
 #  annotations:
 #    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"cmk", "value":"true"}]'
   name: cmk-uninstall-pod
-  #namespace: user-supplied-namespace        
+  namespace: intel-cmk        
 spec:
   serviceAccountName: cmk-serviceaccount
 # Needed for k8s >= 1.7

--- a/resources/pods/cmk-uninstall-pod.yaml
+++ b/resources/pods/cmk-uninstall-pod.yaml
@@ -21,7 +21,7 @@ metadata:
 #  annotations:
 #    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"cmk", "value":"true"}]'
   name: cmk-uninstall-pod
-  namespace: intel-cmk        
+  namespace: cmk-namespace        
 spec:
   serviceAccountName: cmk-serviceaccount
 # Needed for k8s >= 1.7

--- a/resources/webhook/cmk-webhook-config.yaml
+++ b/resources/webhook/cmk-webhook-config.yaml
@@ -9,7 +9,7 @@ webhooks:
     caBundle: BASE64_ENCODED_CERT
     service:
       name: cmk-webhook-service
-      namespace: default
+      namespace: cmk-namespace
       path: /mutate
   failurePolicy: Ignore
   name: cmk.intel.com


### PR DESCRIPTION
Summary:
- Promote good practices for Kubernetes by creating dedicated namespaces for operators and avoid using "default" namespaces
- Update components to use "intel-cmk" as the namespace and avoid using "default"
- Update Pod template definition to use the cmk-serviceaccount instead of default

Changes:
- cmk-cluster-init-pod.yaml: update to use intel-cmk as the default namespace for deployment
- k8s.py: update get_pod_template to use CMK service account (default to cmk-serviceaccount)
- Update pods and daemonset definitions in ./resources/pods/ to use intel-cmk as default namespace
- cmk-rbac-rules.yaml: update to use intel-cmk for the RBAC
- cmk-serviceaccount.yaml: update to use intel-cmk as namespace for the ServiceAccount