### PR TITLE
Added version requirement for attrs library in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ cryptography>=2.3, <=2.4.2
 yamlreader==3.0.4
 pluggy>=0.5, <0.7
 packaging==17.1
-attrs==18.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ cryptography>=2.3, <=2.4.2
 yamlreader==3.0.4
 pluggy>=0.5, <0.7
 packaging==17.1
+attrs==18.1.0


### PR DESCRIPTION
Tests were failing after the recent update to the attrs library in pytest. Set the requirement for attrs to 18.1.0 to fix this.