### PR TITLE
Add support for Kubernetes v1.16

### DIFF
--- a/intel/discover.py
+++ b/intel/discover.py
@@ -29,7 +29,7 @@ from . import k8s
 # the appropriate CMK node labels and taints.
 def discover(conf_dir):
 
-    version = util.parse_version(k8s.get_kubelet_version(None))
+    version = util.parse_version(k8s.get_kube_version(None))
     if version == util.parse_version("v1.8.0"):
         logging.fatal("K8s 1.8.0 is not supported. Update K8s to "
                       "version >=1.8.1 or rollback to previous versions")
@@ -139,7 +139,7 @@ def add_node_taint():
         logging.error("Aborting discover ...")
         sys.exit(1)
 
-    version = util.parse_version(k8s.get_kubelet_version(None))
+    version = util.parse_version(k8s.get_kube_version(None))
     node_taints_list = []
     node_taints = []
 

--- a/intel/nodereport.py
+++ b/intel/nodereport.py
@@ -40,7 +40,7 @@ def nodereport(conf_dir, seconds, publish):
             k8sconfig.load_incluster_config()
             v1beta = k8sclient.ExtensionsV1beta1Api()
 
-            version = util.parse_version(k8s.get_kubelet_version(None))
+            version = util.parse_version(k8s.get_kube_version(None))
 
             if version >= util.parse_version("v1.7.0"):
                 node_report_type = \

--- a/intel/reconcile.py
+++ b/intel/reconcile.py
@@ -44,7 +44,7 @@ def reconcile(conf_dir, seconds, publish):
             k8sconfig.load_incluster_config()
             v1beta = k8sclient.ExtensionsV1beta1Api()
 
-            version = util.parse_version(k8s.get_kubelet_version(None))
+            version = util.parse_version(k8s.get_kube_version(None))
 
             if version >= util.parse_version("v1.7.0"):
                 reconcile_report_type = \

--- a/intel/uninstall.py
+++ b/intel/uninstall.py
@@ -68,7 +68,7 @@ def remove_binary(install_dir):
 
 
 def remove_all_report():
-    version = util.parse_version(k8s.get_kubelet_version(None))
+    version = util.parse_version(k8s.get_kube_version(None))
 
     if version >= util.parse_version("v1.7.0"):
         remove_report_crd("cmk-nodereport", ["cmk-nr"])
@@ -146,7 +146,8 @@ def delete_cmk_pod(pod_base_name, namespace, postfix=None,):
             # Pod is part of DaemonSet - remove ds otherwise ds
             # controller will restart pod
             logging.info("\"{}\" is DaemonSet".format(pod_name))
-            k8s.delete_ds(None, pod_name, namespace)
+            api_version = util.parse_version(k8s.get_kube_version(None))
+            k8s.delete_ds(None, api_version, pod_name, namespace)
         else:
             k8s.delete_pod(None, pod_name, namespace)
     except K8sApiException as err:
@@ -259,7 +260,7 @@ def remove_node_taint():
                       "\"{}\" obj: {}".format(node_name, err))
         sys.exit(1)
 
-    version = util.parse_version(k8s.get_kubelet_version(None))
+    version = util.parse_version(k8s.get_kube_version(None))
     node_taints_list = []
 
     if version >= util.parse_version("v1.7.0"):
@@ -299,7 +300,7 @@ def remove_node_taint():
 
 
 def remove_resource_tracking():
-    version = util.parse_version(k8s.get_kubelet_version(None))
+    version = util.parse_version(k8s.get_kube_version(None))
     if version == util.parse_version("v1.8.0"):
         logging.warning("Unsupported Kubernetes version")
     elif version >= util.parse_version("v1.8.1"):
@@ -354,7 +355,7 @@ def remove_node_cmk_er():
 
 
 def remove_webhook_resources(prefix, namespace):
-    version = util.parse_version(k8s.get_kubelet_version(None))
+    version = util.parse_version(k8s.get_kube_version(None))
     if version >= util.parse_version("v1.9.0"):
         try:
             k8s.delete_mutating_webhook_configuration(

--- a/resources/authorization/cmk-rbac-rules.yaml
+++ b/resources/authorization/cmk-rbac-rules.yaml
@@ -27,8 +27,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cmk-daemonset-controller
 rules:
-- apiGroups: ["extensions"]
-  resources: ["daemonsets", "daemonsets.extensions"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["daemonsets", "daemonsets.extensions", "daemonsets.apps"]
   verbs: ["*"]
 ---
 kind: ClusterRole
@@ -47,6 +47,15 @@ metadata:
 rules:
 - apiGroups: ["", "apps", "extensions", "admissionregistration.k8s.io"]
   resources: ["secrets", "configmaps", "deployments", "services", "mutatingwebhookconfigurations"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cmk-node-lister
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
   verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -122,6 +131,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cmk-webhook-installer
+subjects:
+- kind: ServiceAccount
+  name: cmk-serviceaccount
+  namespace: cmk-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cmk-role-binding-node-lister
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cmk-node-lister
 subjects:
 - kind: ServiceAccount
   name: cmk-serviceaccount

--- a/resources/pods/cmk-nodereport-daemonset-legacy.yaml
+++ b/resources/pods/cmk-nodereport-daemonset-legacy.yaml
@@ -12,24 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   labels:
-    app: cmk-reconcile-ds-all
+    app: cmk-node-report-ds-all
 # Needed for k8s < 1.7
 #  annotations:
 #    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"cmk", "value":"true"}]'
-  name: cmk-reconcile-ds-all
+  name: cmk-node-report-ds-all
   namespace: cmk-namespace
 spec:
-  selector:
-    matchLabels:
-      app: cmk-reconcile-ds-all
   template:
     metadata:
       labels:
-        app: cmk-reconcile-ds-all
+        app: cmk-node-report-ds-all
     spec:
       serviceAccountName: cmk-serviceaccount
 # Needed for k8s >= 1.7
@@ -37,14 +34,14 @@ spec:
 #      - operator: "Exists"
       containers:
       - args:
-        - "/cmk/cmk.py isolate --pool=infra /cmk/cmk.py -- reconcile --interval=$CMK_RECONCILE_SLEEP_TIME --publish"
+        - "/cmk/cmk.py isolate --pool=infra /cmk/cmk.py -- node-report --interval=$CMK_NODE_REPORT_SLEEP_TIME --publish"
         command:
         - "/bin/bash"
         - "-c"
         env:
-        - name: CMK_RECONCILE_SLEEP_TIME
+        - name: CMK_NODE_REPORT_SLEEP_TIME
           # Change this to modify the sleep interval between consecutive
-          # cmk reconcile runs. The value is specified in seconds.
+          # cmk node report runs. The value is specified in seconds.
           value: '60'
         - name: CMK_PROC_FS
           value: "/host/proc"
@@ -53,7 +50,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         image: cmk:v1.3.1
-        name: cmk-reconcile
+        name: cmk-nodereport
         volumeMounts:
         - mountPath: "/host/proc"
           name: host-proc

--- a/resources/pods/cmk-nodereport-daemonset.yaml
+++ b/resources/pods/cmk-nodereport-daemonset.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -23,6 +23,9 @@ metadata:
   name: cmk-node-report-ds-all
   namespace: cmk-namespace
 spec:
+  selector:
+    matchLabels:
+      app: cmk-node-report-ds-all
   template:
     metadata:
       labels:

--- a/resources/pods/cmk-reconcile-daemonset-legacy.yaml
+++ b/resources/pods/cmk-reconcile-daemonset-legacy.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   labels:
@@ -23,9 +23,6 @@ metadata:
   name: cmk-reconcile-ds-all
   namespace: cmk-namespace
 spec:
-  selector:
-    matchLabels:
-      app: cmk-reconcile-ds-all
   template:
     metadata:
       labels:

--- a/resources/pods/cmk-uninstall-all-daemonset-legacy.yaml
+++ b/resources/pods/cmk-uninstall-all-daemonset-legacy.yaml
@@ -12,40 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   labels:
-    app: cmk-reconcile-ds-all
+    app: cmk-uninstall-all-nodes
 # Needed for k8s < 1.7
 #  annotations:
 #    "scheduler.alpha.kubernetes.io/tolerations": '[{"key":"cmk", "value":"true"}]'
-  name: cmk-reconcile-ds-all
+  name: cmk-uninstall-all-nodes
   namespace: cmk-namespace
 spec:
-  selector:
-    matchLabels:
-      app: cmk-reconcile-ds-all
   template:
     metadata:
       labels:
-        app: cmk-reconcile-ds-all
+        app: cmk-uninstall-all-nodes
     spec:
       serviceAccountName: cmk-serviceaccount
 # Needed for k8s >= 1.7
 #      tolerations:
 #      - operator: "Exists"
+      nodeSelector:
+        "cmk.intel.com/cmk-node": "true"
       containers:
       - args:
-        - "/cmk/cmk.py isolate --pool=infra /cmk/cmk.py -- reconcile --interval=$CMK_RECONCILE_SLEEP_TIME --publish"
+        - "/cmk/cmk.py uninstall"
         command:
         - "/bin/bash"
         - "-c"
         env:
-        - name: CMK_RECONCILE_SLEEP_TIME
-          # Change this to modify the sleep interval between consecutive
-          # cmk reconcile runs. The value is specified in seconds.
-          value: '60'
         - name: CMK_PROC_FS
           value: "/host/proc"
         - name: NODE_NAME
@@ -53,13 +48,15 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         image: cmk:v1.3.1
-        name: cmk-reconcile
+        name: cmk-uninstall-all-nodes
         volumeMounts:
+        - mountPath: "/etc/cmk"
+          name: cmk-conf-dir
         - mountPath: "/host/proc"
           name: host-proc
           readOnly: true
-        - mountPath: "/etc/cmk"
-          name: cmk-conf-dir
+        - mountPath: "/opt/bin"
+          name: cmk-install-dir
       volumes:
       - hostPath:
           path: "/proc"
@@ -68,3 +65,7 @@ spec:
           # Change this to modify the CMK config dir in the host file system.
           path: "/etc/cmk"
         name: cmk-conf-dir
+      - hostPath:
+          # Change this to modify the CMK installation dir in the host file system.
+          path: "/opt/bin"
+        name: cmk-install-dir

--- a/resources/pods/cmk-uninstall-all-daemonset.yaml
+++ b/resources/pods/cmk-uninstall-all-daemonset.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2019 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -23,6 +23,9 @@ metadata:
   name: cmk-uninstall-all-nodes
   namespace: cmk-namespace
 spec:
+  selector:
+    matchLabels:
+      app: cmk-uninstall-all-nodes
   template:
     metadata:
       labels:

--- a/tests/unit/test_clusterinit.py
+++ b/tests/unit/test_clusterinit.py
@@ -133,6 +133,7 @@ HTTP response body: fake body
     return exp_log_err
 
 
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.8.0"))
 def test_clusterinit_run_cmd_pods_init_failure(caplog):
     fake_http_resp = FakeHTTPResponse(500, "fake reason", "fake body")
     fake_api_exception = K8sApiException(http_resp=fake_http_resp)
@@ -149,6 +150,7 @@ def test_clusterinit_run_cmd_pods_init_failure(caplog):
         assert caplog_tuple[1][2] == exp_log_err
 
 
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.8.0"))
 def test_clusterinit_run_cmd_pods_discover_failure(caplog):
     fake_http_resp = FakeHTTPResponse(500, "fake reason", "fake body")
     fake_api_exception = K8sApiException(http_resp=fake_http_resp)
@@ -165,6 +167,7 @@ def test_clusterinit_run_cmd_pods_discover_failure(caplog):
         assert caplog_tuple[1][2] == exp_log_err
 
 
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.8.0"))
 def test_clusterinit_run_cmd_pods_install_failure(caplog):
     fake_http_resp = FakeHTTPResponse(500, "fake reason", "fake body")
     fake_api_exception = K8sApiException(http_resp=fake_http_resp)
@@ -181,7 +184,7 @@ def test_clusterinit_run_cmd_pods_install_failure(caplog):
         assert caplog_tuple[1][2] == exp_log_err
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.5.1"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.5.1"))
 def test_clusterinit_run_cmd_pods_reconcile_failure(caplog):
     fake_http_resp = FakeHTTPResponse(500, "fake reason", "fake body")
     fake_api_exception = K8sApiException(http_resp=fake_http_resp)
@@ -198,7 +201,7 @@ def test_clusterinit_run_cmd_pods_reconcile_failure(caplog):
         assert caplog_tuple[1][2] == exp_log_err
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.5.1"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.5.1"))
 def test_clusterinit_run_cmd_pods_nodereport_failure(caplog):
     fake_http_resp = FakeHTTPResponse(500, "fake reason", "fake body")
     fake_api_exception = K8sApiException(http_resp=fake_http_resp)
@@ -242,7 +245,7 @@ def test_clusterinit_node_list_host_list():
 
 
 @patch('intel.clusterinit.wait_for_pod_phase', MagicMock(return_value=True))
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.5.1"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.5.1"))
 def test_clusterinit_pass_pull_secrets():
     mock = MagicMock()
     with patch('intel.k8s.client_from_config', MagicMock(return_value=mock)):
@@ -261,7 +264,7 @@ def test_clusterinit_pass_pull_secrets():
 
 
 @patch('intel.clusterinit.wait_for_pod_phase', MagicMock(return_value=True))
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.5.1"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.5.1"))
 def test_clusterinit_dont_pass_pull_secrets():
     mock = MagicMock()
     with patch('intel.k8s.client_from_config',
@@ -278,7 +281,7 @@ def test_clusterinit_dont_pass_pull_secrets():
 
 
 @patch('intel.clusterinit.wait_for_pod_phase', MagicMock(return_value=True))
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.5.1"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.5.1"))
 def test_clusterinit_pass_serviceaccountname():
     mock = MagicMock()
     serviceaccount_name = "testSAname"
@@ -297,7 +300,7 @@ def test_clusterinit_pass_serviceaccountname():
 
 
 @patch('intel.clusterinit.wait_for_pod_phase', MagicMock(return_value=True))
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.5.1"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.5.1"))
 def test_clusterinit_dont_pass_serviceaccountname():
     mock = MagicMock()
     with patch('intel.k8s.client_from_config', MagicMock(return_value=mock)):
@@ -314,7 +317,7 @@ def test_clusterinit_dont_pass_serviceaccountname():
         assert sa_name_in_spec == ""
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.5.1"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.5.1"))
 def test_clusterinit_update_pod_with_init_container():
     pod_passed = k8sclient.V1Pod(
         metadata=k8sclient.V1ObjectMeta(annotations={}),

--- a/tests/unit/test_discover.py
+++ b/tests/unit/test_discover.py
@@ -111,7 +111,7 @@ def test_discover_add_taint_failure1(caplog):
         assert caplog_tuple[0][2] == exp_log_err
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.5.1"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.5.1"))
 def test_discover_add_taint_failure2(caplog):
     fake_node_resp = {
             "metadata": {
@@ -148,7 +148,7 @@ def test_add_node_er_failure(caplog):
         assert caplog_tuple[-1][2] == "Aborting discover ..."
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value='v1.10.0'))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value='v1.10.0'))
 def test_discover_version_check(caplog):
     conf_dir = helpers.conf_dir("ok")
     with patch('intel.discover.add_node_er') as mock_er, \
@@ -164,7 +164,7 @@ def test_discover_version_check(caplog):
         assert mock_taint.called
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value='v1.6.0'))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value='v1.6.0'))
 def test_discover_version_check2(caplog):
     conf_dir = helpers.conf_dir("ok")
     with patch('intel.discover.add_node_er') as mock_er, \
@@ -180,7 +180,7 @@ def test_discover_version_check2(caplog):
         assert mock_taint.called
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value='v1.8.0'))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value='v1.8.0'))
 def test_discover_version_check3(caplog):
     conf_dir = helpers.conf_dir("ok")
     with patch('intel.discover.add_node_er') as mock_er, \

--- a/tests/unit/test_uninstall.py
+++ b/tests/unit/test_uninstall.py
@@ -62,7 +62,7 @@ def test_uninstall_remove_node_cmk_oir_failure(caplog):
         assert caplog_tuple[-1][2] == exp_log_err
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.6.3"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.6.3"))
 def test_remove_all_report_tpr_success(caplog):
     mock = MagicMock()
     mock.remove.return_value = 0
@@ -82,7 +82,7 @@ def test_remove_all_report_tpr_success(caplog):
                                       "removed.".format(os.getenv("NODE_NAME"))
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.7.4"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.7.4"))
 def test_remove_all_report_crd_success(caplog):
     mock = MagicMock()
     mock.remove.return_value = 0
@@ -254,7 +254,7 @@ def test_uninstall_remove_node_taint_failure1(caplog):
         assert caplog_tuple[-1][2] == exp_log_err
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.5.1"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.5.1"))
 def test_uninstall_remove_node_taint_failure2(caplog):
     fake_node_resp = {
             "metadata": {
@@ -460,6 +460,7 @@ def test_delete_cmk_pod_failure(caplog):
         assert caplog_tuple[-1][2] == exp_log_err
 
 
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.8.0"))
 def test_delete_cmk_pod_failure2(caplog):
     fake_http_resp = FakeHTTPResponse(500, "{\"message\":\"fake message\"}",
                                       "{\"reason\":\"WrongReason\"}")
@@ -479,6 +480,7 @@ def test_delete_cmk_pod_failure2(caplog):
         assert caplog_tuple[-1][2] == exp_log_err
 
 
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.8.0"))
 def test_delete_cmk_pod_success(caplog):
     fake_http_resp = FakeHTTPResponse(500, "{\"message\":\"fake message\"}",
                                       "{\"reason\":\"NotFound\"}")
@@ -515,7 +517,7 @@ def test_delete_cmk_pod_success2(caplog):
                 pod_base_name, str(os.getenv("NODE_NAME")))
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.10.0"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.10.0"))
 def test_remove_resource_tracking_er_removed(caplog):
     mock = MagicMock()
     with patch('intel.uninstall.remove_node_cmk_er', mock):
@@ -523,7 +525,7 @@ def test_remove_resource_tracking_er_removed(caplog):
         assert mock.called
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.6.0"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.6.0"))
 def test_remove_resource_tracking_oir_removed(caplog):
     mock = MagicMock()
     with patch('intel.uninstall.remove_node_cmk_oir', mock):
@@ -531,7 +533,7 @@ def test_remove_resource_tracking_oir_removed(caplog):
         assert mock.called
 
 
-@patch('intel.k8s.get_kubelet_version', MagicMock(return_value="v1.8.0"))
+@patch('intel.k8s.get_kube_version', MagicMock(return_value="v1.8.0"))
 def test_remove_resource_tracking_unsupported(caplog):
     uninstall.remove_resource_tracking()
     caplog_tuple = caplog.record_tuples


### PR DESCRIPTION
* When running on Kubernetes v1.9.0 or newer, apps/v1 DaemonSet API will
be used to create reconcile/nodereport ds
* On Kubernetes older than v1.9.0 legacy extensions/v1beta1 API will be
used (the same that got deprecated in v1.16).
* Update tests.
* Add RBAC rules that allow CMK clusterinit to modify apps/v1 DS resources.
* Update template DaemonSet specs and move deprecated ones to
'*-legacy.yaml' files.

Signed-off-by: Przemysław Lal <przemyslawx.lal@intel.com>