### PR TITLE
Add setuptools requirement for integration tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ yamlreader==3.0.4
 pluggy>=0.5, <0.7
 packaging==17.1
 attrs==18.1.0
+setuptools==39.1.0


### PR DESCRIPTION
Fixes issue with test_cmk_install which was failing due to a ModuleNotFoundError