### PR TITLE
Add additional pool exclusive-non-isolcpus

### DIFF
--- a/cmk.py
+++ b/cmk.py
@@ -25,9 +25,11 @@ Usage:
                    [--num-shared-cores=<num>] [--pull-secret=<name>]
                    [--saname=<name>] [--shared-mode=<mode>]
                    [--exclusive-mode=<mode>] [--namespace=<name>]
+                   [--excl-non-isolcpus=<list>]
   cmk init [--conf-dir=<dir>] [--num-exclusive-cores=<num>]
            [--num-shared-cores=<num>] [--socket-id=<num>]
            [--shared-mode=<mode>] [--exclusive-mode=<mode>]
+           [--excl-non-isolcpus=<list>]
   cmk discover [--conf-dir=<dir>]
   cmk describe [--conf-dir=<dir>]
   cmk reconcile [--conf-dir=<dir>] [--publish] [--interval=<seconds>]
@@ -79,6 +81,10 @@ Options:
   --namespace=<name>           Set the namespace to deploy pods to during the
                                cluster-init deployment process.
                                [default: default].
+  --excl-non-isolcpus=<list>   List of physical cores to be added to the extra
+                               exclusive pool, not governed by isolcpus. Both
+                               hyperthreads of the core will be added to the pool
+                               [default: -1]
 """  # noqa: E501
 from intel import (
     clusterinit, describe, discover, init, install,
@@ -102,14 +108,16 @@ def main():
                                  args["--num-shared-cores"],
                                  args["--pull-secret"],
                                  args["--saname"], args["--exclusive-mode"],
-                                 args["--shared-mode"], args["--namespace"])
+                                 args["--shared-mode"], args["--namespace"],
+                                 args["--excl-non-isolcpus"])
         return
     if args["init"]:
         init.init(args["--conf-dir"],
                   int(args["--num-exclusive-cores"]),
                   int(args["--num-shared-cores"]),
                   args["--exclusive-mode"],
-                  args["--shared-mode"])
+                  args["--shared-mode"],
+                  args["--excl-non-isolcpus"])
         return
     if args["discover"]:
         discover.discover(args["--conf-dir"])

--- a/docs/config.md
+++ b/docs/config.md
@@ -50,6 +50,34 @@ etc
             └── exclusive
 ```
 
+_Example with extra exclusive-non-isolcpus pool configured:_
+
+```           
+etc
+└── cmk
+    ├── lock
+    └── pools
+        ├── shared
+        │   ├── 3,11
+        │   │   └── tasks
+        │   └── exclusive
+        ├── exclusive
+        │   ├── 4,12
+        │   │   └── tasks
+        │   ├── 5,13
+        │   │   └── tasks
+        ├── infra
+        |   ├── 0-2,8-10
+        |   │   └── tasks
+        |   └── exclusive
+        └── exclusive-non-isolcpus
+            ├── 6,14
+            │   └── tasks
+            ├── 7,15
+            │   └── tasks
+            └── exclusive
+```
+
 _Where:_
 
 | Path                                    | Meaning |

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -131,6 +131,15 @@ The above command prepares all the nodes in the Kubernetes cluster for the `CMK`
 The above command prepares nodes "node1", "node2" and "node3" but only runs the `cmk init` and `cmk discover`
 subcommands on each of those nodes.
 
+```yml
+  - args:
+      # Change this value to pass different options to cluster-init.
+      - "/cmk/cmk.py cluster-init --host-list=node1,node2,node3 --num-exclusive-cores=3 --num-shared-cores=1 --excl-non-isolcpus=11-15"
+```
+The above command prepares nodes "node1", "node2" and "node3" to have 3 cores placed in the _exclusive_ pool, 1 core 
+placed in the _shared_ pool, and the cores 11-15 placed in the _exclusive-non-isolcpus_ pool. The _exclusive-non-isolcpus_ 
+pool will isolate pods from other pods in the cluster, but will not use cores that are governed by isolcpus.
+
 For more details on the options provided by `cmk cluster-init`, see this [description][cmk-cluster-init].
 
 ### Prepare `CMK` nodes by running each `CMK` subcommand as a Pod.

--- a/intel/isolate.py
+++ b/intel/isolate.py
@@ -36,7 +36,7 @@ def isolate(conf_dir, pool_name, no_affinity, command, args, socket_id=None):
                            .format(pool_name))
         pool = pools[pool_name]
 
-        socket_aware_pools = ["exclusive", "shared"]
+        socket_aware_pools = ["exclusive", "shared", "exclusive-non-isolcpus"]
         if socket_id == "-1" or pool_name not in socket_aware_pools:
             selected_socket = None
         else:

--- a/intel/topology.py
+++ b/intel/topology.py
@@ -347,14 +347,14 @@ def parse_isolcpus(cmdline):
 
         if key == "isolcpus":
             cpus_str = value.split(",")
-            cpus += parse_cpus_from_isolcpus(cpus_str)
+            cpus += parse_cpus_str(cpus_str)
 
     # Get unique cpu_ids from list
     cpus = list(set(cpus))
     return cpus
 
 
-def parse_cpus_from_isolcpus(cpus_str):
+def parse_cpus_str(cpus_str):
     cpus = []
     for cpu_id in cpus_str:
         if "-" not in cpu_id:

--- a/resources/pods/cmk-isolate-excl-non-isolcpus-pod-no-webhook.yaml
+++ b/resources/pods/cmk-isolate-excl-non-isolcpus-pod-no-webhook.yaml
@@ -1,0 +1,65 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# NOTE: To be used with k8s >= 1.8.1, < 1.9.0 (or with k8s >= 1.9.0 if webhook is not used).
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: cmk-isolate-pod
+  name: cmk-isolate-pod
+  namespace: cmk-namespace
+spec:
+  serviceAccountName: cmk-serviceaccount
+  tolerations:
+  - operator: "Exists"
+  restartPolicy: Never
+  containers:
+  - name: cmk-isolate-exclusive-non-isolcpus
+    image: cmk:v1.4.0
+    command:
+    - "/bin/bash"
+    - "-c"
+    args:
+    - "/opt/bin/cmk isolate --conf-dir=/etc/cmk --pool=exclusive-non-isolcpus echo -- Hello World Exclusive-Non-Isolcpus!!!"
+    resources:
+      requests:
+        cmk.intel.com/exclusive-non-isolcpus-cores: '1'
+      limits:
+        cmk.intel.com/exclusive-non-isolcpus-cores: '1'
+    env:
+    - name: CMK_PROC_FS
+      value: "/host/proc"
+    volumeMounts:
+    - mountPath: "/host/proc"
+      name: cmk-host-proc
+      readOnly: true
+    - mountPath: "/opt/bin"
+      name: cmk-install-dir
+    - mountPath: "/etc/cmk"
+      name: cmk-conf-dir
+  volumes:
+  - hostPath:
+      # Change this to modify the CMK installation dir in the host file system.
+      path: "/opt/bin"
+    name: cmk-install-dir
+  - hostPath:
+      path: "/proc"
+    name: cmk-host-proc
+  - hostPath:
+      # Change this to modify the CMK config dir in the host file system.
+      path: "/etc/cmk"
+    name: cmk-conf-dir

--- a/resources/pods/cmk-isolate-excl-non-isolcpus-pod.yaml
+++ b/resources/pods/cmk-isolate-excl-non-isolcpus-pod.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# NOTE: To be used with k8s >= 1.9.0 (if webhook is running).
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: cmk-isolate-pod
+  name: cmk-isolate-pod
+# Consumed by mutating webhook
+  annotations:
+    cmk.intel.com/mutate: "true" # accepted values to trigger mutation: "true", "True", "1"
+  namespace: cmk-namespace
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cmk-isolate-exclusive-non-isolcpus
+    image: cmk:v1.4.0
+    command:
+    - "/bin/bash"
+    - "-c"
+    args:
+    - "/opt/bin/cmk isolate --conf-dir=/etc/cmk --pool=exclusive-non-isolcpus echo -- Hello World Exclusive-Non-Isolcpus!!!"
+    resources:
+      requests:
+        cmk.intel.com/exclusive-non-isolcpus-cores: '1'
+      limits:
+        cmk.intel.com/exclusive-non-isolcpus-cores: '1'

--- a/tests/data/sysfs/exclusive_non_isolcpus/proc/1/status
+++ b/tests/data/sysfs/exclusive_non_isolcpus/proc/1/status
@@ -1,0 +1,1 @@
+Cpus_allowed_list: 5,13

--- a/tests/data/sysfs/exclusive_non_isolcpus/proc/cmdline
+++ b/tests/data/sysfs/exclusive_non_isolcpus/proc/cmdline
@@ -1,0 +1,1 @@
+BOOT_IMAGE=/boot/vmlinuz-4.4.14-040414-generic root=/dev/md2 ro net.ifnames=0 isolcpus=1,2,9,10

--- a/tests/data/sysfs/sst_cp_isolcpus/proc/1/status
+++ b/tests/data/sysfs/sst_cp_isolcpus/proc/1/status
@@ -1,0 +1,1 @@
+Cpus_allowed_list: 5,13

--- a/tests/data/sysfs/sst_cp_isolcpus/proc/cmdline
+++ b/tests/data/sysfs/sst_cp_isolcpus/proc/cmdline
@@ -1,0 +1,1 @@
+BOOT_IMAGE=/boot/vmlinuz-4.4.14-040414-generic root=/dev/md2 ro net.ifnames=0 isolcpus=1,2,3,4,6,7,8,9

--- a/tests/integration/test_cmk_help.py
+++ b/tests/integration/test_cmk_help.py
@@ -28,9 +28,11 @@ Usage:
                    [--num-shared-cores=<num>] [--pull-secret=<name>]
                    [--saname=<name>] [--shared-mode=<mode>]
                    [--exclusive-mode=<mode>] [--namespace=<name>]
+                   [--excl-non-isolcpus=<list>]
   cmk init [--conf-dir=<dir>] [--num-exclusive-cores=<num>]
            [--num-shared-cores=<num>] [--socket-id=<num>]
            [--shared-mode=<mode>] [--exclusive-mode=<mode>]
+           [--excl-non-isolcpus=<list>]
   cmk discover [--conf-dir=<dir>]
   cmk describe [--conf-dir=<dir>]
   cmk reconcile [--conf-dir=<dir>] [--publish] [--interval=<seconds>]
@@ -82,4 +84,8 @@ Options:
   --namespace=<name>           Set the namespace to deploy pods to during the
                                cluster-init deployment process.
                                [default: default].
+  --excl-non-isolcpus=<list>   List of physical cores to be added to the extra
+                               exclusive pool, not governed by isolcpus. Both
+                               hyperthreads of the core will be added to the pool
+                               [default: -1]
 """  # noqa: E501

--- a/tests/integration/test_cmk_init.py
+++ b/tests/integration/test_cmk_init.py
@@ -32,7 +32,8 @@ proc_env_ok = {
 
 def test_cmk_init():
     args = ["init",
-            "--conf-dir={}".format(os.path.join(tempfile.mkdtemp(), "init"))]
+            "--conf-dir={}".format(os.path.join(tempfile.mkdtemp(), "init")),
+            "--excl-non-isolcpus=-1"]
 
     helpers.execute(integration.cmk(), args, proc_env_ok)
 

--- a/tests/unit/test_clusterinit.py
+++ b/tests/unit/test_clusterinit.py
@@ -25,7 +25,7 @@ def test_clusterinit_invalid_cmd_list_failure1():
         clusterinit.cluster_init("fakenode1", False, "fakecmd1, fakecmd2",
                                  "cmk", "Never", "/etc/cmk", "/opt/bin",
                                  "4", "2", "", "", "vertical", "vertical",
-                                 "default")
+                                 "default", "-1")
     expected_err_msg = ("CMK command should be one of "
                         "['init', 'discover', 'install', 'reconcile', "
                         "'nodereport']")
@@ -37,7 +37,7 @@ def test_clusterinit_invalid_cmd_list_failure2():
         clusterinit.cluster_init("fakenode1", False, "fakecmd1, init",
                                  "cmk", "Never", "/etc/cmk", "/opt/bin",
                                  "4", "2", "", "", "vertical", "vertical",
-                                 "default")
+                                 "default", "-1")
     expected_err_msg = ("CMK command should be one of "
                         "['init', 'discover', 'install', 'reconcile', "
                         "'nodereport']")
@@ -49,7 +49,7 @@ def test_clusterinit_invalid_cmd_list_failure3():
         clusterinit.cluster_init("fakenode1", False, "init, fakecmd1, install",
                                  "cmk", "Never", "/etc/cmk", "/opt/bin",
                                  "4", "2", "", "", "vertical", "vertical",
-                                 "default")
+                                 "default", "-1")
     expected_err_msg = ("CMK command should be one of "
                         "['init', 'discover', 'install', 'reconcile', "
                         "'nodereport']")
@@ -61,7 +61,7 @@ def test_clusterinit_invalid_cmd_list_failure4():
         clusterinit.cluster_init("fakenode1", False, "discover, init",
                                  "cmk", "Never", "/etc/cmk", "/opt/bin",
                                  "4", "2", "", "", "vertical", "vertical",
-                                 "default")
+                                 "default", "-1")
     expected_err_msg = "init command should be run and listed first."
     assert err.value.args[0] == expected_err_msg
 
@@ -70,7 +70,7 @@ def test_clusterinit_invalid_image_pol():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "init", "cmk", "fakepol1",
                                  "/etc/cmk", "/opt/bin", "4", "2", "", "",
-                                 "vertical", "vertical", "default")
+                                 "vertical", "vertical", "default", "-1")
     expected_err_msg = ('Image pull policy should be one of '
                         '[\'Never\', \'IfNotPresent\', \'Always\']')
     assert err.value.args[0] == expected_err_msg
@@ -80,7 +80,7 @@ def test_clusterinit_invalid_exclusive_cores_failure1():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "init", "cmk", "Never",
                                  "/etc/cmk", "/opt/bin", "-1", "2", "", "",
-                                 "vertical", "vertical", "default")
+                                 "vertical", "vertical", "default", "-1")
     expected_err_msg = ("num_exclusive_cores cores should be a positive "
                         "integer.")
     assert err.value.args[0] == expected_err_msg
@@ -90,7 +90,7 @@ def test_clusterinit_invalid_exclusive_cores_failure2():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "init", "cmk", "Never",
                                  "/etc/cmk", "/opt/bin", "3.5", "2", "", "",
-                                 "vertical", "vertical", "default")
+                                 "vertical", "vertical", "default", "-1")
     expected_err_msg = ("num_exclusive_cores cores should be a positive "
                         "integer.")
     assert err.value.args[0] == expected_err_msg
@@ -100,7 +100,7 @@ def test_clusterinit_invalid_shared_cores_failure1():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "init", "cmk", "Never",
                                  "/etc/cmk", "/opt/bin", "1", "2.5", "", "",
-                                 "vertical", "vertical", "default")
+                                 "vertical", "vertical", "default", "-1")
     expected_err_msg = "num_shared_cores cores should be a positive integer."
     assert err.value.args[0] == expected_err_msg
 
@@ -109,7 +109,7 @@ def test_clusterinit_invalid_shared_cores_failure2():
     with pytest.raises(RuntimeError) as err:
         clusterinit.cluster_init("fakenode1", False, "init", "cmk", "Never",
                                  "/etc/cmk", "/opt/bin", "1", "10.5", "", "",
-                                 "vertical", "vertical", "default")
+                                 "vertical", "vertical", "default", "-1")
     expected_err_msg = "num_shared_cores cores should be a positive integer."
     assert err.value.args[0] == expected_err_msg
 
@@ -143,7 +143,7 @@ def test_clusterinit_run_cmd_pods_init_failure(caplog):
             clusterinit.run_pods(None, ["init"], "fake_img",
                                  "Never", "fake-conf-dir", "fake-install-dir",
                                  "2", "2", ["fakenode"], "", "", "vertical",
-                                 "vertical", "default")
+                                 "vertical", "default", "-1")
         exp_err = "Exception when creating pod for ['init'] command(s)"
         exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
@@ -160,7 +160,7 @@ def test_clusterinit_run_cmd_pods_discover_failure(caplog):
             clusterinit.run_pods(None, ["discover"], "fake_img", "Never",
                                  "fake-conf-dir", "fake-install-dir", "2",
                                  "2", ["fakenode"], "", "", "vertical",
-                                 "vertical", "default")
+                                 "vertical", "default", "-1")
         exp_err = "Exception when creating pod for ['discover'] command(s)"
         exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
@@ -177,7 +177,7 @@ def test_clusterinit_run_cmd_pods_install_failure(caplog):
             clusterinit.run_pods(None, ["install"], "fake_img", "Never",
                                  "fake-conf-dir", "fake-install-dir", "2",
                                  "2", ["fakenode"], "", "", "vertical",
-                                 "vertical", "default")
+                                 "vertical", "default", "-1")
         exp_err = "Exception when creating pod for ['install'] command(s)"
         exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
@@ -194,7 +194,7 @@ def test_clusterinit_run_cmd_pods_reconcile_failure(caplog):
             clusterinit.run_pods(["reconcile"], None, "fake_img", "Never",
                                  "fake-conf-dir", "fake-install-dir", "2",
                                  "2", ["fakenode"], "", "", "vertical",
-                                 "vertical", "default")
+                                 "vertical", "default", "-1")
         exp_err = "Exception when creating pod for ['reconcile'] command(s)"
         exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
@@ -211,7 +211,7 @@ def test_clusterinit_run_cmd_pods_nodereport_failure(caplog):
             clusterinit.run_pods(["nodereport"], None, "fake_img", "Never",
                                  "fake-conf-dir", "fake-install-dir", "2",
                                  "2", ["fakenode"], "", "", "vertical",
-                                 "vertical", "default")
+                                 "vertical", "default", "-1")
         exp_err = "Exception when creating pod for ['nodereport'] command(s)"
         exp_log_err = get_expected_log_error(exp_err)
         caplog_tuple = caplog.record_tuples
@@ -253,7 +253,7 @@ def test_clusterinit_pass_pull_secrets():
                                  "init, discover, install",
                                  "cmk", "Never", "/etc/cmk", "/opt/bin",
                                  "4", "2", "supersecret", "", "vertical",
-                                 "vertical", "default")
+                                 "vertical", "default", "-1")
         called_methods = mock.method_calls
         params = called_methods[0][1]
         pod_spec = params[1]
@@ -273,7 +273,7 @@ def test_clusterinit_dont_pass_pull_secrets():
                                  "init, discover, install",
                                  "cmk", "Never", "/etc/cmk", "/opt/bin",
                                  "4", "2", "", "", "vertical", "vertical",
-                                 "default")
+                                 "default", "-1")
         called_methods = mock.method_calls
         params = called_methods[0][1]
         pod_spec = params[1]
@@ -290,7 +290,7 @@ def test_clusterinit_pass_serviceaccountname():
                                  "init, discover, install",
                                  "cmk", "Never", "/etc/cmk", "/opt/bin",
                                  "4", "2", "", serviceaccount_name,
-                                 "vertical", "vertical", "default")
+                                 "vertical", "vertical", "default", "-1")
         called_methods = mock.method_calls
         params = called_methods[0][1]
         pod_spec = params[1]
@@ -308,7 +308,7 @@ def test_clusterinit_dont_pass_serviceaccountname():
                                  "init, discover, install",
                                  "cmk", "Never", "/etc/cmk", "/opt/bin",
                                  "4", "2", "", "", "vertical", "vertical",
-                                 "default")
+                                 "default", "-1")
         called_methods = mock.method_calls
         params = called_methods[0][1]
         pod_spec = params[1]
@@ -363,7 +363,7 @@ def test_clusterinit_run_pods_failure(caplog):
             clusterinit.run_pods(None, ["discover"], "fake_img", "Never",
                                  "fake-conf-dir", "fake-install-dir", "2",
                                  "2", ["fakenode"], "", "", "vertical",
-                                 "vertical", "default")
+                                 "vertical", "default", "-1")
         caplog_tuple = caplog.record_tuples
         assert caplog_tuple[-2][2] == "{}".format(fake_exception)
         assert caplog_tuple[-1][2] == "Aborting cluster-init ..."

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -10,10 +10,24 @@ def get_cmk_container():
     fake_cmk_container = {
         "resources": {
             "requests": {
-                webhook.CMK_ER_NAME: "2"
+                webhook.CMK_ER_NAME[0]: "2"
             },
             "limits": {
-                webhook.CMK_ER_NAME: "2"
+                webhook.CMK_ER_NAME[0]: "2"
+            },
+        }
+    }
+    return fake_cmk_container
+
+
+def get_cmk_container2():
+    fake_cmk_container = {
+        "resources": {
+            "requests": {
+                webhook.CMK_ER_NAME[1]: "2"
+            },
+            "limits": {
+                webhook.CMK_ER_NAME[1]: "2"
             },
         }
     }
@@ -88,6 +102,16 @@ def test_webhook_container_mutation_required():
     assert still_required
 
 
+def test_webhook_container_mutation_required2():
+    container = get_cmk_container2()
+    required = webhook.is_container_mutation_required(container)
+    assert required
+
+    container["resources"].pop("requests")
+    still_required = webhook.is_container_mutation_required(container)
+    assert still_required
+
+
 def test_webhook_container_mutation_not_required():
     container = {}
     required = webhook.is_container_mutation_required(container)
@@ -100,6 +124,17 @@ def test_webhook_mutation_required():
             "containers": [get_cmk_container()]
         }
     }
+    required = webhook.is_mutation_required(pod)
+    assert required
+
+
+def test_wehbook_mutation_required2():
+    pod = {
+        "spec": {
+            "containers": [get_cmk_container2()]
+        }
+    }
+
     required = webhook.is_mutation_required(pod)
     assert required
 


### PR DESCRIPTION
Add an additional pool called exclusive-non-isolcpus. This pool is used with cores that are to be isolated from other pods in the cluster but are not allocated as isolcpus. The PR adds a new flag _--excl-non-isolcpus=\<list\>_ which has a default value of "-1".

If the value passed is "-1" then CMK does not get configured with this extra pool and functions as normal.

If a list of cores or a range of cores are given then CMK is configured with these cores placed in the exclusive-non-isolcpus pool