### PR TITLE
update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,16 @@
 tox>=2.5, <3.0
 docopt>=0.6, <1.0
-psutil>=5.0, <5.5
+psutil>=5.6.6, <5.7
 pyinstaller>=3.2, <4.0
 kubernetes==10.0.0
 requests>=2.21, <3.0
 urllib3==1.24.2
 pytest<=3.3.2
 pytest-cov>=2.4.0, <2.6.1
+coverage<=4.5.4
 cryptography>=2.3, <=2.4.2
 yamlreader==3.0.4
 pluggy>=0.5, <0.7
 packaging==17.1
 attrs==18.1.0
-setuptools==39.1.0
+setuptools==41.0.1


### PR DESCRIPTION
* update psutil to >=5.6.6,<5.7 to resolve CVE-2019-18874
* update setuptools to 41.0.1 to resolve compatibility with other reqs
reported during Docker image build
* add coverage <=4.5.4 to requirements.txt to resolve compatibility
issues with automatically detected >5.0.0 version

Signed-off-by: Przemysław Lal <przemyslawx.lal@intel.com>