### PR TITLE
Add shared CPUs environment variable

### DIFF
--- a/intel/isolate.py
+++ b/intel/isolate.py
@@ -23,6 +23,7 @@ import subprocess
 
 ENV_CPUS_ASSIGNED = "CMK_CPUS_ASSIGNED"
 ENV_CPUS_ASSIGNED_MASK = "CMK_CPUS_ASSIGNED_MASK"
+ENV_CPUS_SHARED = "CMK_CPUS_SHARED"
 ENV_CPUS_INFRA = "CMK_CPUS_INFRA"
 ENV_NUM_CORES = "CMK_NUM_CORES"
 
@@ -89,6 +90,14 @@ def isolate(conf_dir, pool_name, no_affinity, command, args, socket_id=None):
         cpus_arr = [int(n) for n in cpu_ids.split(',')]
         cpus_bit_mask = util.convert_array2bitmask(cpus_arr)
         os.environ[ENV_CPUS_ASSIGNED_MASK] = cpus_bit_mask
+
+        # Advertise shared pool CPU IDs
+        shared_pool = pools.get("shared")
+        if shared_pool is not None:
+            shared_clists = [cl.cpus()
+                             for cl
+                             in shared_pool.cpu_lists().values()]
+            os.environ[ENV_CPUS_SHARED] = ','.join(shared_clists)
 
         # Advertise infra pool CPU IDs
         infra_pool = pools.get("infra")

--- a/tests/integration/test_cmk_isolate.py
+++ b/tests/integration/test_cmk_isolate.py
@@ -35,6 +35,7 @@ def test_cmk_isolate_child_env():
     assert helpers.execute(integration.cmk(), args, proc_env) == b"""\
 CMK_CPUS_ASSIGNED=0
 CMK_CPUS_ASSIGNED_MASK=1
+CMK_CPUS_SHARED=0
 CMK_PROC_FS=/proc
 """
 
@@ -48,6 +49,7 @@ def test_cmk_isolate_child_env_infra():
     assert helpers.execute(integration.cmk(), args, proc_env) == b"""\
 CMK_CPUS_ASSIGNED=1
 CMK_CPUS_ASSIGNED_MASK=2
+CMK_CPUS_SHARED=1
 CMK_CPUS_INFRA=0
 CMK_PROC_FS=/proc
 """
@@ -200,6 +202,7 @@ def test_cmk_isolate_multiple_cores_exclusive():
     assert helpers.execute(integration.cmk(), args, env) == b"""\
 CMK_CPUS_ASSIGNED=0,1
 CMK_CPUS_ASSIGNED_MASK=3
+CMK_CPUS_SHARED=0
 CMK_PROC_FS=/proc
 CMK_NUM_CORES=2
 """
@@ -215,6 +218,7 @@ def test_cmk_isolate_multiple_cores_shared():
     assert helpers.execute(integration.cmk(), args, env) == b"""\
 CMK_CPUS_ASSIGNED=0
 CMK_CPUS_ASSIGNED_MASK=1
+CMK_CPUS_SHARED=0
 CMK_PROC_FS=/proc
 CMK_NUM_CORES=2
 """


### PR DESCRIPTION
Adds the environment variable for shared CPUs that allows a program to pin itself to the cores in the shared pool as it does for the infrastructure pool.