### PR TITLE
fix isolate.py

### DIFF
--- a/intel/isolate.py
+++ b/intel/isolate.py
@@ -148,7 +148,7 @@ command because the --no-affinity flag was supplied""")
         node_name = k8s.get_node_from_pod(None, pod_name)
         configmap_name = "cmk-config-{}".format(node_name)
 
-        c = config.Config(configmap_name, pod_name)
+        c = config.Config(configmap_name, pod_name, namespace)
         c.lock()
         pool = c.get_pool(pool_name)
         pid = str(proc.getpid())


### PR DESCRIPTION
isolate.py is currently broken as it attempts to create config without namespace

Traceback (most recent call last):
  File "./cmk.py", line 216, in <module>
    main()
  File "./cmk.py", line 151, in main
    isolate.isolate(args["--pool"],
  File "/cmk/intel/isolate.py", line 151, in isolate
    c = config.Config(configmap_name, pod_name)
TypeError: __init__() missing 1 required positional argument: 'cm_namespace'